### PR TITLE
Add guarded club membership workflow

### DIFF
--- a/api/_setReservation.ts
+++ b/api/_setReservation.ts
@@ -3,8 +3,8 @@ import { sanitize } from './_lib.js';
 import { getJwtPayload } from './verifyAuth.js';
 import {
   getAllReservations,
-  isReservationActive
 } from '../src/utils/utils.js';
+import { isReservationActive } from '../src/utils/reservations.js';
 import {
   getReservationError,
   validateReservationBody,

--- a/api/login.ts
+++ b/api/login.ts
@@ -64,7 +64,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
                 if (authenticated) {
                     const role = user.role || 'player';
 
-                    if (!user.club_id || !user.first_name || !user.last_name) {
+                    if (!user.first_name || !user.last_name) {
                       throw new Error('Benutzerkonto ist unvollständig konfiguriert.');
                     }
                     const secret = new TextEncoder().encode(jwtSecret);
@@ -73,7 +73,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
                       _id: user._id.toString(),
                       first_name: user.first_name,
                       last_name: user.last_name,
-                      club_id: user.club_id,
+                      club_id: user.club_id ?? '',
                       email: user.email,
                       role,
                       status: user.status ?? 'active',

--- a/api/select-club.ts
+++ b/api/select-club.ts
@@ -83,7 +83,7 @@ function buildClubChangeNotificationEmail(
         <tr><td><strong>Neuer Verein</strong></td><td>${escapeHtml(toClubName ?? '-')}</td></tr>
       </tbody>
     </table>
-    ${membersUrl ? `<p><a href="${escapeHtml(membersUrl)}">Inaktive Mitglieder anzeigen</a></p>` : ''}
+    ${membersUrl ? `<p style="margin-top: 16px;"><a href="${escapeHtml(membersUrl)}" style="display: inline-block; padding: 10px 16px; background: #3264c8; color: #ffffff; text-decoration: none; border-radius: 4px;">Neue Mitglieder aktivieren</a></p>` : ''}
   `;
 }
 

--- a/api/select-club.ts
+++ b/api/select-club.ts
@@ -5,6 +5,7 @@ import { getJwtPayload } from './verifyAuth.js';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { DBUser, ReservationItem } from '../src/types.js';
 import sendEmail from './_sendEmail.js';
+import { isReservationActive } from '../src/utils/reservations.js';
 
 type ClubDocument = {
   name?: string;
@@ -22,17 +23,6 @@ const validationError = (message: string) => ({
     }
   ]
 });
-
-const isReservationActive = (reservation: ReservationItem, now = new Date()) => {
-  if (reservation.recurring) {
-    return true;
-  }
-
-  const reservationEndTime = new Date(reservation.date);
-  reservationEndTime.setHours(reservation.end_time, 0, 0, 0);
-
-  return reservationEndTime > now;
-};
 
 async function deleteActiveReservationsForUser(
   reservationsCollection: ReturnType<MongoClient['db']>['collection'],

--- a/api/select-club.ts
+++ b/api/select-club.ts
@@ -34,11 +34,47 @@ const isReservationActive = (reservation: ReservationItem, now = new Date()) => 
   return reservationEndTime > now;
 };
 
-function buildClubChangeNotificationEmail(user: Pick<DBUser, 'first_name' | 'last_name' | 'email'>, fromClubName?: string, toClubName?: string) {
+async function deleteActiveReservationsForUser(
+  reservationsCollection: ReturnType<MongoClient['db']>['collection'],
+  userId: string,
+  clubId?: string
+) {
+  const reservations = await reservationsCollection.find({
+    user_id: userId,
+    ...(clubId ? {club_id: clubId} : {})
+  }).toArray() as ReservationItem[];
+  const activeReservationIds = reservations
+    .filter(reservation => isReservationActive(reservation))
+    .map(reservation => reservation._id)
+    .filter((id): id is ObjectId => Boolean(id));
+
+  if (!activeReservationIds.length) {
+    return 0;
+  }
+
+  const deleteResult = await reservationsCollection.deleteMany({
+    _id: {$in: activeReservationIds}
+  });
+
+  return deleteResult.deletedCount;
+}
+
+const getAppOrigin = (req: VercelRequest) => {
+  const protocol = req.headers['x-forwarded-proto'] ?? 'https';
+  const host = req.headers.host;
+  return host ? `${protocol}://${host}` : '';
+};
+
+function buildClubChangeNotificationEmail(
+  user: Pick<DBUser, 'first_name' | 'last_name' | 'email'>,
+  fromClubName?: string,
+  toClubName?: string,
+  membersUrl?: string
+) {
   const fullName = `${user.first_name} ${user.last_name}`.trim();
 
   return `
-    <p>Ein Spieler hat den Verein gewechselt.</p>
+    <p>Ein Spieler hat seine Vereinszuordnung geändert.</p>
     <table cellpadding="6" cellspacing="0" style="border-collapse: collapse;">
       <tbody>
         <tr><td><strong>Name</strong></td><td>${escapeHtml(fullName)}</td></tr>
@@ -47,6 +83,7 @@ function buildClubChangeNotificationEmail(user: Pick<DBUser, 'first_name' | 'las
         <tr><td><strong>Neuer Verein</strong></td><td>${escapeHtml(toClubName ?? '-')}</td></tr>
       </tbody>
     </table>
+    ${membersUrl ? `<p><a href="${escapeHtml(membersUrl)}">Inaktive Mitglieder anzeigen</a></p>` : ''}
   `;
 }
 
@@ -96,97 +133,123 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 
     if (req.method === 'POST') {
       const body = sanitize(req.body);
-      const { club_id } = body;
+      const { club_id, action } = body;
+      const payload = await getJwtPayload(req);
+      if (!payload) {
+        return res.status(401).json({error: 'Authentication required'});
+      }
 
-      // add club_id to user who posted the club
-      if (club_id) {
-        const payload = await getJwtPayload(req);
-        if (!payload) {
-          return res.status(401).json({error: 'Authentication required'});
+      const requester = await userCollection.findOne({
+        _id: ObjectId.createFromHexString(payload._id)
+      });
+      if (!requester) {
+        return res.status(401).json({error: 'Authentication required'});
+      }
+      if (requester.role === 'admin') {
+        return res.status(403).json({error: 'Admins cannot select an existing club'});
+      }
+
+      const previousClubId = requester.club_id;
+      const previousClub = previousClubId ? await clubCollection.findOne({
+        _id: ObjectId.createFromHexString(previousClubId)
+      }) : null;
+      const query = {_id: ObjectId.createFromHexString(payload._id)};
+
+      if (action === 'leave' || club_id === '') {
+        if (previousClubId) {
+          await deleteActiveReservationsForUser(reservationsCollection, payload._id, previousClubId);
         }
 
-        const requester = await userCollection.findOne({
-          _id: ObjectId.createFromHexString(payload._id)
+        await userCollection.updateOne(query, {
+          $set: {status: 'inactive'},
+          $unset: {club_id: ''}
         });
-        if (!requester) {
-          return res.status(401).json({error: 'Authentication required'});
-        }
-        if (requester.role === 'admin') {
-          return res.status(403).json({error: 'Admins cannot select an existing club'});
-        }
 
-        const club = await clubCollection.findOne({
-          _id: ObjectId.createFromHexString(club_id)
-        });
-        if (!club) {
-          return res.status(404).json(validationError('Verein nicht gefunden.'));
-        }
-
-        if (requester.club_id === club_id) {
-          return res.status(409).json(validationError('Sie sind diesem Verein bereits zugeordnet.'));
-        }
-
-        if (requester.club_id && requester.club_id !== club_id) {
-          const userReservations = await reservationsCollection.find({
-            user_id: payload._id,
-            club_id: requester.club_id
-          }).toArray();
-          const hasActiveReservations = userReservations.some(reservation => isReservationActive(reservation));
-
-          if (hasActiveReservations) {
-            return res.status(409).json(validationError('Bitte stornieren Sie zuerst Ihre aktiven Reservierungen, bevor Sie den Verein wechseln.'));
-          }
-        }
-
-        const previousClubId = requester.club_id;
-        const previousClub = previousClubId ? await clubCollection.findOne({
-          _id: ObjectId.createFromHexString(previousClubId)
-        }) : null;
-
-        const query = {_id: ObjectId.createFromHexString(payload._id)};
-        const updateResonse = await userCollection.updateOne(
-            query,
-            {'$set' : {'club_id' : club_id, 'status': 'active'}}
-        );
-
-        if (previousClubId && previousClubId !== club_id) {
+        if (previousClubId) {
           const html = buildClubChangeNotificationEmail({
             first_name: requester.first_name,
             last_name: requester.last_name,
             email: requester.email,
-          }, previousClub?.name, club.name);
+          }, previousClub?.name, undefined);
 
           try {
-            await Promise.allSettled([
-              notifyClubAdminsOfChange(
-                database,
-                previousClubId,
-                `${requester.first_name} ${requester.last_name} hat ${previousClub?.name ?? 'Ihren Verein'} verlassen`,
-                html
-              ),
-              notifyClubAdminsOfChange(
-                database,
-                club_id,
-                `${requester.first_name} ${requester.last_name} ist ${club.name ?? 'Ihrem Verein'} beigetreten`,
-                html
-              )
-            ]);
+            await notifyClubAdminsOfChange(
+              database,
+              previousClubId,
+              `${requester.first_name} ${requester.last_name} hat ${previousClub?.name ?? 'Ihren Verein'} verlassen`,
+              html
+            );
           } catch (emailError) {
-            console.error('Failed to notify club admins about club change', emailError);
+            console.error('Failed to notify club admins about club leave', emailError);
           }
         }
 
         return res.status(201).json({
-          message: `Added club_id ${club_id} to logged-in user in database.`,
+          message: 'Removed club_id from logged-in user in database.',
           data: {
-            club_id,
-            status: 'active'
+            club_id: '',
+            status: 'inactive'
           }
         });
-      } else {
-        const error = 'No club id was submitted...';
-        res.status(500).json({error})
       }
+
+      if (!club_id) {
+        return res.status(400).json(validationError('Bitte wählen Sie einen gültigen Verein aus.'));
+      }
+
+      const club = await clubCollection.findOne({
+        _id: ObjectId.createFromHexString(club_id)
+      });
+      if (!club) {
+        return res.status(404).json(validationError('Verein nicht gefunden.'));
+      }
+
+      if (requester.club_id === club_id) {
+        return res.status(409).json(validationError('Sie sind diesem Verein bereits zugeordnet.'));
+      }
+
+      if (previousClubId && previousClubId !== club_id) {
+        await deleteActiveReservationsForUser(reservationsCollection, payload._id, previousClubId);
+      }
+
+      await userCollection.updateOne(
+        query,
+        {'$set' : {'club_id' : club_id, 'status': 'inactive'}}
+      );
+
+      const membersUrl = `${getAppOrigin(req)}/admin/members?tab=inactive`;
+      const html = buildClubChangeNotificationEmail({
+        first_name: requester.first_name,
+        last_name: requester.last_name,
+        email: requester.email,
+      }, previousClub?.name, club.name, membersUrl);
+
+      try {
+        await Promise.allSettled([
+          ...(previousClubId && previousClubId !== club_id ? [notifyClubAdminsOfChange(
+            database,
+            previousClubId,
+            `${requester.first_name} ${requester.last_name} hat ${previousClub?.name ?? 'Ihren Verein'} verlassen`,
+            html
+          )] : []),
+          notifyClubAdminsOfChange(
+            database,
+            club_id,
+            `${requester.first_name} ${requester.last_name} wartet auf Freischaltung bei ${club.name ?? 'Ihrem Verein'}`,
+            html
+          )
+        ]);
+      } catch (emailError) {
+        console.error('Failed to notify club admins about club change', emailError);
+      }
+
+      return res.status(201).json({
+        message: `Added club_id ${club_id} to logged-in user in database.`,
+        data: {
+          club_id,
+          status: 'inactive'
+        }
+      });
     }
   } catch (e) {
     console.error(e);

--- a/api/signup.ts
+++ b/api/signup.ts
@@ -14,7 +14,7 @@ type SignupBody = {
     last_name: string;
     email: string;
     password: string;
-    club_id: string;
+    club_id?: string;
 }
 
 if (!database_uri || !database_name) {
@@ -33,7 +33,13 @@ type AdminUserDocument = {
     email?: string;
 }
 
-function buildNewUserNotificationEmail(user: DBUser, club: ClubDocument) {
+const getAppOrigin = (req: VercelRequest) => {
+    const protocol = req.headers['x-forwarded-proto'] ?? 'https';
+    const host = req.headers.host;
+    return host ? `${protocol}://${host}` : '';
+};
+
+function buildNewUserNotificationEmail(user: DBUser, club: ClubDocument, membersUrl: string) {
     const fullName = `${user.first_name} ${user.last_name}`;
     const registeredAt = new Date().toLocaleString('de-DE', {
         dateStyle: 'medium',
@@ -42,38 +48,47 @@ function buildNewUserNotificationEmail(user: DBUser, club: ClubDocument) {
     });
 
     return `
-        <p>Ein neuer Benutzer hat sich bei ${escapeHtml(club.name ?? 'Ihrem Verein')} registriert.</p>
+        <p>Ein neuer Benutzer hat sich bei ${escapeHtml(club.name ?? 'Ihrem Verein')} registriert und wartet auf Freischaltung.</p>
         <table cellpadding="6" cellspacing="0" style="border-collapse: collapse;">
             <tbody>
                 <tr><td><strong>Name</strong></td><td>${escapeHtml(fullName)}</td></tr>
                 <tr><td><strong>E-Mail</strong></td><td>${escapeHtml(user.email)}</td></tr>
                 <tr><td><strong>Rolle</strong></td><td>${escapeHtml(user.role)}</td></tr>
-                <tr><td><strong>Status</strong></td><td>${escapeHtml(user.status)}</td></tr>
+                <tr><td><strong>Status</strong></td><td>${escapeHtml(user.status ?? 'inactive')}</td></tr>
                 <tr><td><strong>Verein</strong></td><td>${escapeHtml(club.name)}</td></tr>
-                <tr><td><strong>Vereins-ID</strong></td><td>${escapeHtml(user.club_id)}</td></tr>
+                <tr><td><strong>Vereins-ID</strong></td><td>${escapeHtml(user.club_id ?? '-')}</td></tr>
                 <tr><td><strong>Registriert am</strong></td><td>${escapeHtml(registeredAt)}</td></tr>
             </tbody>
         </table>
+        <p><a href="${escapeHtml(membersUrl)}">Inaktive Mitglieder anzeigen</a></p>
     `;
 }
 
-function buildWelcomeEmail(user: DBUser, club: ClubDocument) {
+function buildWelcomeEmail(user: DBUser, club?: ClubDocument) {
+    const hasClub = Boolean(user.club_id && club);
+
     return `
         <p>Hallo ${escapeHtml(user.first_name)},</p>
-        <p>willkommen bei ${escapeHtml(club.name ?? 'Ab zum Platz')}! Ihr Benutzerkonto wurde erfolgreich registriert.</p>
+        <p>willkommen bei ${escapeHtml(hasClub ? club?.name : 'Ab zum Platz')}! Ihr Benutzerkonto wurde erfolgreich registriert.</p>
         <table cellpadding="6" cellspacing="0" style="border-collapse: collapse;">
             <tbody>
                 <tr><td><strong>Name</strong></td><td>${escapeHtml(`${user.first_name} ${user.last_name}`)}</td></tr>
                 <tr><td><strong>E-Mail</strong></td><td>${escapeHtml(user.email)}</td></tr>
-                <tr><td><strong>Verein</strong></td><td>${escapeHtml(club.name)}</td></tr>
-                <tr><td><strong>Status</strong></td><td>${escapeHtml(user.status)}</td></tr>
+                <tr><td><strong>Verein</strong></td><td>${escapeHtml(hasClub ? club?.name : '-')}</td></tr>
+                <tr><td><strong>Status</strong></td><td>${escapeHtml(user.status ?? 'inactive')}</td></tr>
             </tbody>
         </table>
-        <p>Sie können sich jetzt in der App anmelden und Plätze reservieren.</p>
+        ${hasClub
+            ? '<p>Ihr Konto ist derzeit inaktiv. Bitte warten Sie, bis der Vereinsadministrator Ihr Konto freischaltet.</p>'
+            : '<p>Bitte wählen Sie nach dem Login einen Verein aus, um Reservierungen vornehmen zu können.</p>'}
     `;
 }
 
-async function notifyClubAdmins(database: Db, user: DBUser, club: ClubDocument) {
+async function notifyClubAdmins(database: Db, user: DBUser, club: ClubDocument, membersUrl: string) {
+    if (!user.club_id) {
+        return;
+    }
+
     const admins = await database.collection<AdminUserDocument>('users').find({
         club_id: user.club_id,
         role: 'admin',
@@ -91,8 +106,8 @@ async function notifyClubAdmins(database: Db, user: DBUser, club: ClubDocument) 
         return;
     }
 
-    const subject = `Neue Registrierung: ${user.first_name} ${user.last_name}`;
-    const html = buildNewUserNotificationEmail(user, club);
+    const subject = `Neue Registrierung wartet auf Freischaltung: ${user.first_name} ${user.last_name}`;
+    const html = buildNewUserNotificationEmail(user, club, membersUrl);
     const results = await Promise.allSettled(adminEmails.map(email => sendEmail({
         email,
         subject,
@@ -105,10 +120,10 @@ async function notifyClubAdmins(database: Db, user: DBUser, club: ClubDocument) 
     }
 }
 
-async function sendWelcomeEmail(user: DBUser, club: ClubDocument) {
+async function sendWelcomeEmail(user: DBUser, club?: ClubDocument) {
     await sendEmail({
         email: user.email,
-        subject: `Willkommen bei ${club.name ?? 'Ab zum Platz'}`,
+        subject: `Willkommen bei ${club?.name ?? 'Ab zum Platz'}`,
         html: buildWelcomeEmail(user, club),
     });
 }
@@ -134,38 +149,47 @@ export default async (req: VercelRequest, res: VercelResponse) => {
                 return res.status(500).json({error: 'Ungültige Daten.'});
             }
         } else {
-            const { first_name, last_name, password, club_id } = body;
+            const { first_name, last_name, password } = body;
+            const club_id = body.club_id?.trim();
             const email = body.email.toLowerCase();
             const user: DBUser = {
                 first_name,
                 last_name,
                 email,
                 password,
-                club_id,
+                ...(club_id ? {club_id} : {}),
                 role: 'player',
-                status: 'active',
+                status: 'inactive',
             };
 
             try {
                 await client.connect();
                 const database = client.db(database_name);
-                if (!objectIdPattern.test(club_id)) {
-                    throw createError('Der ausgewählte Verein existiert nicht.', 'club_id');
+                let club: ClubDocument | null = null;
+
+                if (club_id) {
+                    if (!objectIdPattern.test(club_id)) {
+                        throw createError('Der ausgewählte Verein existiert nicht.', 'club_id');
+                    }
+                    club = await database.collection<ClubDocument>('clubs').findOne({
+                        _id: ObjectId.createFromHexString(club_id)
+                    });
+                    if (!club) {
+                        throw createError('Der ausgewählte Verein existiert nicht.', 'club_id');
+                    }
                 }
-                const club = await database.collection<ClubDocument>('clubs').findOne({
-                    _id: ObjectId.createFromHexString(club_id)
-                });
-                if (!club) {
-                    throw createError('Der ausgewählte Verein existiert nicht.', 'club_id');
-                }
+
                 await addUser(database, user);
-                try {
-                    await notifyClubAdmins(database, user, club);
-                } catch (notificationError) {
-                    console.error('Failed to notify club admins about new user registration', notificationError);
+                if (club && club_id) {
+                    try {
+                        const membersUrl = `${getAppOrigin(req)}/admin/members?tab=inactive`;
+                        await notifyClubAdmins(database, user, club, membersUrl);
+                    } catch (notificationError) {
+                        console.error('Failed to notify club admins about new user registration', notificationError);
+                    }
                 }
                 try {
-                    await sendWelcomeEmail(user, club);
+                    await sendWelcomeEmail(user, club ?? undefined);
                 } catch (welcomeEmailError) {
                     console.error('Failed to send welcome email after new user registration', welcomeEmailError);
                 }
@@ -174,7 +198,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
                 });
             } catch (e) {
                 console.error(e);
-                const instancePath = (getErrorCause(e) === 'invalid_email') ? '/email' : '/undefined';
+                const instancePath = getErrorCause(e) === 'invalid_email' ? '/email' : `/${getErrorCause(e) ?? 'undefined'}`;
                 res.status(500).json({error: [
                     {
                         instancePath: instancePath,

--- a/api/signup.ts
+++ b/api/signup.ts
@@ -60,7 +60,9 @@ function buildNewUserNotificationEmail(user: DBUser, club: ClubDocument, members
                 <tr><td><strong>Registriert am</strong></td><td>${escapeHtml(registeredAt)}</td></tr>
             </tbody>
         </table>
-        <p><a href="${escapeHtml(membersUrl)}">Inaktive Mitglieder anzeigen</a></p>
+        <p style="margin-top: 16px;">
+            <a href="${escapeHtml(membersUrl)}" style="display: inline-block; padding: 10px 16px; background: #3264c8; color: #ffffff; text-decoration: none; border-radius: 4px;">Neue Mitglieder aktivieren</a>
+        </p>
     `;
 }
 

--- a/api/users.ts
+++ b/api/users.ts
@@ -5,6 +5,7 @@ import { getJwtPayload } from './verifyAuth.js';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import sendEmail from './_sendEmail.js';
 import { escapeHtml } from './_lib.js';
+import { ReservationItem } from '../src/types.js';
 
 type ClubDocument = {
   name?: string;
@@ -12,6 +13,43 @@ type ClubDocument = {
 
 function getStatusLabel(status: string) {
   return status === 'active' ? 'aktiv' : 'inaktiv';
+}
+
+const isReservationActive = (reservation: ReservationItem, now = new Date()) => {
+  if (reservation.recurring) {
+    return true;
+  }
+
+  const reservationEndTime = new Date(reservation.date);
+  reservationEndTime.setHours(reservation.end_time, 0, 0, 0);
+
+  return reservationEndTime > now;
+};
+
+async function deleteActiveReservationsForUser(
+  database: ReturnType<MongoClient['db']>,
+  userId: string,
+  clubId?: string
+) {
+  const reservationsCollection = database.collection<ReservationItem>('reservations');
+  const reservations = await reservationsCollection.find({
+    user_id: userId,
+    ...(clubId ? {club_id: clubId} : {})
+  }).toArray();
+  const activeReservationIds = reservations
+    .filter(reservation => isReservationActive(reservation))
+    .map(reservation => reservation._id)
+    .filter((id): id is ObjectId => Boolean(id));
+
+  if (!activeReservationIds.length) {
+    return 0;
+  }
+
+  const deleteResult = await reservationsCollection.deleteMany({
+    _id: {$in: activeReservationIds}
+  });
+
+  return deleteResult.deletedCount;
 }
 
 function buildStatusChangedEmail(
@@ -35,6 +73,29 @@ function buildStatusChangedEmail(
       </tbody>
     </table>
     <p>Bei Fragen zu dieser Änderung wenden Sie sich bitte an ${escapeHtml(adminName || 'die Vereinsverwaltung')} (${escapeHtml(adminContact?.email ?? '-')}).</p>
+  `;
+}
+
+function buildRemovedFromClubEmail(
+  targetUser: { first_name?: string; last_name?: string; email?: string },
+  clubName?: string,
+  adminContact?: { first_name?: string; last_name?: string; email?: string }
+) {
+  const fullName = `${targetUser.first_name ?? ''} ${targetUser.last_name ?? ''}`.trim();
+  const adminName = `${adminContact?.first_name ?? ''} ${adminContact?.last_name ?? ''}`.trim();
+
+  return `
+    <p>Hallo ${escapeHtml(targetUser.first_name ?? '')},</p>
+    <p>Sie wurden aus ${escapeHtml(clubName ?? 'Ihrem Verein')} entfernt.</p>
+    <table cellpadding="6" cellspacing="0" style="border-collapse: collapse;">
+      <tbody>
+        <tr><td><strong>Name</strong></td><td>${escapeHtml(fullName)}</td></tr>
+        <tr><td><strong>E-Mail</strong></td><td>${escapeHtml(targetUser.email)}</td></tr>
+        <tr><td><strong>Verein</strong></td><td>${escapeHtml(clubName ?? '-')}</td></tr>
+      </tbody>
+    </table>
+    <p>Ihr Konto bleibt bestehen, ist aber keinem Verein mehr zugeordnet. Aktive Reservierungen wurden entfernt.</p>
+    <p>Bei Fragen wenden Sie sich bitte an ${escapeHtml(adminName || 'die Vereinsverwaltung')} (${escapeHtml(adminContact?.email ?? '-')}).</p>
   `;
 }
 
@@ -98,15 +159,14 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       }
     }
 
-    // update user status
     if (req.method === 'POST') {
       const user_id = req.body.user_id;
       const status = req.body.status;
-      // console.log(user_id, status);
-      if (!user_id || !status) {
+      const action = req.body.action;
+      if (!user_id || (!status && action !== 'remove')) {
         throw new Error('You did not provide user id or status');
       }
-      if (!['active', 'inactive'].includes(status)) {
+      if (status && !['active', 'inactive'].includes(status)) {
         return res.status(400).json({error: 'Invalid status'});
       }
 
@@ -122,7 +182,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         return res.status(401).json({error: 'Authentication required'});
       }
       if (requester.role !== 'admin') {
-        return res.status(403).json({error: 'Only admins can update member status'});
+        return res.status(403).json({error: 'Only admins can update members'});
       }
 
       const query = {_id: ObjectId.createFromHexString(user_id)};
@@ -132,6 +192,59 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       }
       if (targetUser.club_id !== requester.club_id) {
         return res.status(403).json({error: 'Updating this member is not allowed'});
+      }
+      if (targetUser.role === 'admin') {
+        return res.status(403).json({error: 'Admin users cannot be changed here'});
+      }
+
+      const club = requester.club_id ? await clubCollection.findOne({
+        _id: ObjectId.createFromHexString(requester.club_id)
+      }) : null;
+
+      if (action === 'remove') {
+        if (targetUser.status === 'active') {
+          return res.status(400).json({error: 'Only inactive members can be removed from club'});
+        }
+
+        await deleteActiveReservationsForUser(database, user_id, requester.club_id);
+        const result = await collection.updateOne(query, {
+          $set: {status: 'inactive'},
+          $unset: {club_id: ''}
+        });
+
+        if (result.modifiedCount > 0) {
+          if (targetUser.email) {
+            try {
+              await sendEmail({
+                email: targetUser.email,
+                subject: `Sie wurden aus ${club?.name ?? 'Ihrem Verein'} entfernt`,
+                html: buildRemovedFromClubEmail({
+                  first_name: targetUser.first_name,
+                  last_name: targetUser.last_name,
+                  email: targetUser.email,
+                }, club?.name, {
+                  first_name: requester.first_name,
+                  last_name: requester.last_name,
+                  email: requester.email,
+                }),
+              });
+            } catch (emailError) {
+              console.error('Failed to send member removal email', emailError);
+            }
+          }
+
+          return res.json({
+            _id: targetUser._id.toString(),
+            club_id: null,
+            status: 'inactive'
+          });
+        }
+
+        return res.status(404).json({error: `User with id ${user_id} not found!`});
+      }
+
+      if (status === 'inactive') {
+        await deleteActiveReservationsForUser(database, user_id, requester.club_id);
       }
 
       const updateDoc = {
@@ -144,9 +257,6 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         const user = await collection.findOne(query, {projection: {password: 0, club_id: 0}});
         if (targetUser.email) {
           try {
-            const club = requester.club_id ? await clubCollection.findOne({
-              _id: ObjectId.createFromHexString(requester.club_id)
-            }) : null;
             await sendEmail({
               email: targetUser.email,
               subject: `Ihr Kontostatus bei ${club?.name ?? 'Ab zum Platz'} wurde aktualisiert`,

--- a/api/users.ts
+++ b/api/users.ts
@@ -6,6 +6,7 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
 import sendEmail from './_sendEmail.js';
 import { escapeHtml } from './_lib.js';
 import { ReservationItem } from '../src/types.js';
+import { isReservationActive } from '../src/utils/reservations.js';
 
 type ClubDocument = {
   name?: string;
@@ -14,17 +15,6 @@ type ClubDocument = {
 function getStatusLabel(status: string) {
   return status === 'active' ? 'aktiv' : 'inaktiv';
 }
-
-const isReservationActive = (reservation: ReservationItem, now = new Date()) => {
-  if (reservation.recurring) {
-    return true;
-  }
-
-  const reservationEndTime = new Date(reservation.date);
-  reservationEndTime.setHours(reservation.end_time, 0, 0, 0);
-
-  return reservationEndTime > now;
-};
 
 async function deleteActiveReservationsForUser(
   database: ReturnType<MongoClient['db']>,

--- a/public/schema/signup.json
+++ b/public/schema/signup.json
@@ -36,11 +36,7 @@
             ]
         },
         "club_id": {
-            "type": "string",
-            "minLength": 1,
-            "errorMessage": {
-              "minLength": "Bitte wählen Sie einen gültigen Wert aus."
-            }
+            "type": "string"
         },
         "email": {
             "type": "string",
@@ -54,7 +50,7 @@
                     "errorMessage": "Die E-Mail-Adresse ist zu lang."
                 },
                 {
-                    "pattern": "^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$",
+                    "pattern": "^[a-zA-Z0-9.!#$%&'*+\/?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$",
                     "errorMessage": "Dies ist keine gültige E-Mail-Adresse."
                 }
             ]
@@ -91,6 +87,6 @@
             }
         }
     },
-    "required": ["first_name", "last_name", "club_id", "email", "password", "privacy"],
+    "required": ["first_name", "last_name", "email", "password", "privacy"],
     "additionalProperties": false
 }

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -11,18 +11,22 @@ export const ProtectedRoute = ({children}: ProtectedRouteProps) => {
     const location = useLocation();
     const auth = useSelector((state: RootState) => state.auth);
     const isLoggedin = auth.value;
+    const isReservationRoute = ['/reservations', '/bookings'].includes(location.pathname);
     // console.log('ProtectedRoute', {isLoggedin}, {role}, location.pathname)
 
     if (!isLoggedin) {
         return <Navigate to="/" replace />;
     } else {
         if (auth.role !== 'admin' && location.pathname.startsWith('/admin')) {
-            // console.log('redirecting non-admin user to /reservations page');
             return <Navigate to="/reservations" replace />;
         }
 
         if (location.pathname === '/select-club' && auth.role === 'admin') {
             return <Navigate to="/admin" replace />;
+        }
+
+        if (auth.role !== 'admin' && isReservationRoute && !auth.club_id) {
+            return <Navigate to="/select-club" replace />;
         }
 
         return children;

--- a/src/app.css
+++ b/src/app.css
@@ -148,12 +148,25 @@ ul {
 }
 
 .users-list {
-    .user-list-item--admin {
-        background: #e8f1ff;
+    .members-list-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        flex-wrap: wrap;
+    }
+
+    .members-list-name--admin {
+        font-weight: 700;
+    }
+
+    .members-action-button {
+        margin-left: 0.5rem;
+        min-width: 0;
+        min-height: 0;
+        padding: 0.5em 1em;
     }
 
     .user-list-item--inactive {
-        background: #f7f7f7;
         color: #888;
 
         a {

--- a/src/components/form/Form.css
+++ b/src/components/form/Form.css
@@ -142,7 +142,7 @@
 
     select {
         border: 1px #ccc solid;
-        padding: 0.25em 0.5em;
+        padding: 0.25em 0;
         display: block;
         width: 100%;
         box-sizing: border-box;

--- a/src/components/selectClub/SelectClub.tsx
+++ b/src/components/selectClub/SelectClub.tsx
@@ -5,6 +5,8 @@ import { useDispatch } from 'react-redux'
 import { useNavigate } from "react-router";
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
+import { useState } from 'react';
+import { Loader } from '../loader/Loader';
 
 type Props = {
     clubs: Club[];
@@ -22,6 +24,7 @@ export function SelectClub(props: Props) {
     const navigate = useNavigate();
     const dispatch = useDispatch();
     const auth = useSelector((state: RootState) => state.auth);
+    const [pending, setPending] = useState(false);
     const clubs = props.clubs
         .filter(club => club._id !== auth.club_id)
         .map(club => {
@@ -31,8 +34,7 @@ export function SelectClub(props: Props) {
         }
     });
 
-    // we update logged-in user in state so that user's club_id is available
-    const callback = (response: Response) => {
+    const updateMembershipState = (response: Response) => {
         dispatch({
             type: 'auth/setClubId',
             payload: {
@@ -54,8 +56,39 @@ export function SelectClub(props: Props) {
                 loaded: false
             }
         });
-        navigate('/reservations');
+    };
+
+    // we update logged-in user in state so that user's club_id is available
+    const callback = (response: Response) => {
+        updateMembershipState(response);
+        navigate(response.data.club_id ? '/profile' : '/select-club');
     }
+
+    const leaveClub = async () => {
+        setPending(true);
+        try {
+            const response = await fetch('/api/select-club', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({action: 'leave'})
+            });
+
+            const json = await response.json();
+            if (!response.ok || json.error) {
+                throw new Error(json.error?.[0]?.message ?? json.error ?? 'Verein konnte nicht verlassen werden.');
+            }
+
+            updateMembershipState(json);
+            navigate('/select-club');
+        } catch (error) {
+            console.error(error);
+            alert(error instanceof Error ? error.message : 'Verein konnte nicht verlassen werden.');
+        } finally {
+            setPending(false);
+        }
+    };
 
     // normalize json by adding clubs data to clubs dropdown
     const normalizedFields: Field[] = JSON.parse(JSON.stringify(formJson.fields));
@@ -64,18 +97,34 @@ export function SelectClub(props: Props) {
             if (auth.club_id) {
                 field.label = 'Neuer Verein';
             }
-            field.options.push(...clubs);
+            field.options = [
+                {
+                    label: auth.club_id ? 'Verein auswählen' : 'Keinen Verein auswählen',
+                    value: ''
+                },
+                ...clubs
+            ];
         }
         return field;
     });
 
     return (
-        <Form
-            classNames="select-club"
-            initialData={normalizedFields}
-            formAttributes={formJson.form}
-            label={auth.club_id ? 'Verein wechseln' : 'Absenden'}
-            callback={callback}
-        />
+        <>
+            <Form
+                classNames="select-club"
+                initialData={normalizedFields}
+                formAttributes={formJson.form}
+                label={auth.club_id ? 'Verein wechseln' : 'Absenden'}
+                callback={callback}
+            />
+            {auth.club_id ? (
+                <p>
+                    <button type="button" disabled={pending} onClick={leaveClub}>
+                        {pending ? <Loader size="small" /> : null}
+                        Kein Verein
+                    </button>
+                </p>
+            ) : null}
+        </>
     )
 }

--- a/src/components/selectClub/selectClubForm.json
+++ b/src/components/selectClub/selectClubForm.json
@@ -16,7 +16,7 @@
                     "value": ""
                 }
             ],
-            "required": true,
+            "required": false,
             "value": ""
         }
     ]

--- a/src/components/signup/Signup.tsx
+++ b/src/components/signup/Signup.tsx
@@ -22,7 +22,7 @@ export function Signup() {
     const normalizedFields: Field[] = JSON.parse(JSON.stringify(formJson.fields));
     const clubField = normalizedFields.find(field => field.name === 'club_id');
     if (clubField) {
-        clubField.hint = 'Falls Sie Ihren Verein nicht finden, bitten Sie den Sportwart Ihres Vereins, Ihren Verein auf abzumplatz.de zu registrieren.';
+        clubField.hint = 'Falls Ihr Verein nicht in der Liste erscheint, können Sie sich trotzdem registrieren. Reservierungen sind erst möglich, sobald Ihr Verein ein Konto auf abzumplatz erstellt hat.';
         clubField.options = [
             {
                 label: 'Verein auswählen',

--- a/src/components/signup/signupForm.json
+++ b/src/components/signup/signupForm.json
@@ -21,14 +21,6 @@
             "value": ""
         },
         {
-            "name": "club_id",
-            "label": "Verein",
-            "type": "select",
-            "required": true,
-            "options": [],
-            "value": ""
-        },
-        {
             "name": "email",
             "label": "Email",
             "type": "email",
@@ -44,6 +36,13 @@
             "required": true,
             "hasStrengthIndicator": true,
             "hasDisplayToggle": true,
+            "value": ""
+        },
+        {
+            "name": "club_id",
+            "label": "Verein",
+            "type": "select",
+            "options": [],
             "value": ""
         },
         {

--- a/src/pages/admin/Members.tsx
+++ b/src/pages/admin/Members.tsx
@@ -3,12 +3,14 @@ import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from './../../store';
 import { fetchUsers } from '../../utils/utils';
 import { Loader } from '../../components/loader/Loader';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 
 export default function AdminMembersPage() {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const initialTab = searchParams.get('tab') === 'inactive' ? 'inactive' : 'active';
     const [loading, setLoading] = useState(false);
     const [pending, setPending] = useState(false);
-    const [activeTab, setActiveTab] = useState<'active' | 'inactive'>('active');
+    const [activeTab, setActiveTab] = useState<'active' | 'inactive'>(initialTab);
     const usersData = useSelector((state: RootState) => state.users);
     const user = useSelector((state: RootState) => state.auth);
     const dispatch = useDispatch();
@@ -17,6 +19,11 @@ export default function AdminMembersPage() {
     const activeUsersCount = users.filter(isActiveUser).length;
     const inactiveUsersCount = users.length - activeUsersCount;
     const visibleUsers = users.filter(member => activeTab === 'active' ? isActiveUser(member) : !isActiveUser(member));
+
+    const setTab = (tab: 'active' | 'inactive') => {
+        setActiveTab(tab);
+        setSearchParams(tab === 'inactive' ? {tab} : {});
+    };
 
     useEffect(() => {
         if (!usersData.loaded) {
@@ -28,7 +35,35 @@ export default function AdminMembersPage() {
         }
     }, []);
 
-    
+    const updateUserInStore = (updatedUser: { _id: string; status: string }) => {
+        const users = usersData.value.map(user => {
+            if (user._id === updatedUser._id) {
+                return {
+                    ...user,
+                    status: updatedUser.status
+                }
+            } else {
+                return user;
+            }
+        });
+        dispatch({
+            type: 'users/fetch',
+            payload: {
+                value: users,
+                loaded: true
+            }
+        });
+    };
+
+    const removeUserFromStore = (userId: string) => {
+        dispatch({
+            type: 'users/fetch',
+            payload: {
+                value: usersData.value.filter(user => user._id !== userId),
+                loaded: true
+            }
+        });
+    };
 
     const handleChange: ChangeEventHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
         e.target.value = e.target.checked ? "active" : "inactive";
@@ -50,30 +85,45 @@ export default function AdminMembersPage() {
                 throw new Error('Something went wrong!');
             }
         }).then(data => {
-            // update user status in store
-            const users = usersData.value.map(user => {
-                if (user._id === data._id) {
-                    return {
-                        ...user,
-                        status: data.status
-                    }
-                } else {
-                    return user;
-                }
-            });
-            dispatch({
-                type: 'users/fetch',
-                payload: {
-                    value: users,
-                    loaded: true
-                }
-            });
+            updateUserInStore(data);
             setPending(false);
         }).catch(e => {
             console.error(e);
             setPending(false);
         });
     }
+
+    const handleRemove = async (userId: string) => {
+        if (!confirm('Möchten Sie dieses inaktive Mitglied wirklich aus dem Verein entfernen?')) {
+            return;
+        }
+
+        setPending(true);
+        try {
+            const response = await fetch('/api/users', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    user_id: userId,
+                    action: 'remove'
+                })
+            });
+            const data = await response.json();
+
+            if (!response.ok || data.error) {
+                throw new Error(data.error ?? 'Mitglied konnte nicht entfernt werden.');
+            }
+
+            removeUserFromStore(userId);
+        } catch (error) {
+            console.error(error);
+            alert(error instanceof Error ? error.message : 'Mitglied konnte nicht entfernt werden.');
+        } finally {
+            setPending(false);
+        }
+    };
 
     return (
         loading ? (
@@ -90,7 +140,7 @@ export default function AdminMembersPage() {
                     <button
                         type="button"
                         className={activeTab === 'active' ? 'members-tab members-tab--active' : 'members-tab'}
-                        onClick={() => setActiveTab('active')}
+                        onClick={() => setTab('active')}
                         role="tab"
                         aria-selected={activeTab === 'active'}
                     >
@@ -99,7 +149,7 @@ export default function AdminMembersPage() {
                     <button
                         type="button"
                         className={activeTab === 'inactive' ? 'members-tab members-tab--active' : 'members-tab'}
-                        onClick={() => setActiveTab('inactive')}
+                        onClick={() => setTab('inactive')}
                         role="tab"
                         aria-selected={activeTab === 'inactive'}
                     >
@@ -120,6 +170,16 @@ export default function AdminMembersPage() {
 	                            </label>
 	                            <span style={{ marginLeft: '0.25rem' }}>(<a href={`mailto:${user.email}`}>{user.email}</a>)</span>
 	                            {user.role === 'admin' ? <span> (Admin)</span> : null}
+                                {!isActiveUser(user) && user.role !== 'admin' ? (
+                                    <button
+                                        type="button"
+                                        disabled={pending}
+                                        onClick={() => handleRemove(user._id)}
+                                        style={{ marginLeft: '0.5rem' }}
+                                    >
+                                        Aus Verein entfernen
+                                    </button>
+                                ) : null}
 	                        </li>;
                     })}
                 </ul>

--- a/src/pages/admin/Members.tsx
+++ b/src/pages/admin/Members.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, ChangeEventHandler} from "react";
+import { useState, useEffect } from "react";
 import { useSelector, useDispatch } from 'react-redux'
 import { RootState } from './../../store';
 import { fetchUsers } from '../../utils/utils';
@@ -65,33 +65,31 @@ export default function AdminMembersPage() {
         });
     };
 
-    const handleChange: ChangeEventHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-        e.target.value = e.target.checked ? "active" : "inactive";
+    const handleStatusChange = async (userId: string, status: 'active' | 'inactive') => {
         setPending(true);
-
-        fetch('/api/users', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                user_id: e.target.id,
-                status: e.target.value
-            })
-        }).then(res => {
-            if (res.ok) {
-                return res.json();
-            } else {
-                throw new Error('Something went wrong!');
+        try {
+            const response = await fetch('/api/users', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    user_id: userId,
+                    status
+                })
+            });
+            const data = await response.json();
+            if (!response.ok || data.error) {
+                throw new Error(data.error ?? 'Status konnte nicht geändert werden.');
             }
-        }).then(data => {
             updateUserInStore(data);
+        } catch (error) {
+            console.error(error);
+            alert(error instanceof Error ? error.message : 'Status konnte nicht geändert werden.');
+        } finally {
             setPending(false);
-        }).catch(e => {
-            console.error(e);
-            setPending(false);
-        });
-    }
+        }
+    };
 
     const handleRemove = async (userId: string) => {
         if (!confirm('Möchten Sie dieses inaktive Mitglied wirklich aus dem Verein entfernen?')) {
@@ -140,6 +138,7 @@ export default function AdminMembersPage() {
                     <button
                         type="button"
                         className={activeTab === 'active' ? 'members-tab members-tab--active' : 'members-tab'}
+                        disabled={pending}
                         onClick={() => setTab('active')}
                         role="tab"
                         aria-selected={activeTab === 'active'}
@@ -149,6 +148,7 @@ export default function AdminMembersPage() {
                     <button
                         type="button"
                         className={activeTab === 'inactive' ? 'members-tab members-tab--active' : 'members-tab'}
+                        disabled={pending}
                         onClick={() => setTab('inactive')}
                         role="tab"
                         aria-selected={activeTab === 'inactive'}
@@ -164,18 +164,28 @@ export default function AdminMembersPage() {
 	                        ].filter(Boolean).join(' ');
 
 	                        return <li className={classNames || undefined} key={user._id}>
-                            <label htmlFor={user._id}>
-                                <input id={user._id} type="checkbox" defaultChecked={isActiveUser(user)} onChange={handleChange} />
-                                {user.first_name} {user.last_name}
-	                            </label>
-	                            <span style={{ marginLeft: '0.25rem' }}>(<a href={`mailto:${user.email}`}>{user.email}</a>)</span>
-	                            {user.role === 'admin' ? <span> (Admin)</span> : null}
+                            <div className="members-list-item">
+                                <span className={user.role === 'admin' ? 'members-list-name members-list-name--admin' : 'members-list-name'}>
+                                    {user.first_name} {user.last_name}{user.role === 'admin' ? ' (Admin)' : ''}
+                                </span>
+	                                <span>(<a href={`mailto:${user.email}`}>{user.email}</a>)</span>
+                            </div>
+                                {user.role !== 'admin' ? (
+                                    <button
+                                        type="button"
+                                        className="button-link members-action-button"
+                                        disabled={pending}
+                                        onClick={() => handleStatusChange(user._id, isActiveUser(user) ? 'inactive' : 'active')}
+                                    >
+                                        {isActiveUser(user) ? 'Deaktivieren' : 'Aktivieren'}
+                                    </button>
+                                ) : null}
                                 {!isActiveUser(user) && user.role !== 'admin' ? (
                                     <button
                                         type="button"
+                                        className="button-link members-action-button"
                                         disabled={pending}
                                         onClick={() => handleRemove(user._id)}
-                                        style={{ marginLeft: '0.5rem' }}
                                     >
                                         Aus Verein entfernen
                                     </button>

--- a/src/reducers/authSlice.ts
+++ b/src/reducers/authSlice.ts
@@ -23,7 +23,7 @@ export const authSlice = createSlice({
       state.last_name = action.payload.last_name;
       state.email = action.payload.email;
       state._id = action.payload._id;
-      state.club_id = action.payload.club_id;
+      state.club_id = action.payload.club_id ?? '';
       state.role = action.payload.role;
       state.status = action.payload.status ?? '';
     },

--- a/src/utils/reservations.ts
+++ b/src/utils/reservations.ts
@@ -1,0 +1,12 @@
+import { ReservationItem } from '../types';
+
+export const isReservationActive = (reservation: ReservationItem, now = new Date()) => {
+    if (reservation.recurring) {
+        return true;
+    }
+
+    const reservationEndTime = new Date(reservation.date);
+    reservationEndTime.setHours(reservation.end_time, 0, 0, 0);
+
+    return reservationEndTime > now;
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,6 +3,7 @@ import { RootState, AppDispatch } from './../store';
 import { FormEvent } from "react";
 import * as mongoDB from "mongodb";
 import { ReservationItem, StateUser } from './../types';
+import { isReservationActive } from './reservations';
 
 export async function fetchJson(path: string) {
   const response = await fetch(path);
@@ -63,17 +64,6 @@ export const getUserReservations = () => {
     const userReservations = reservations.filter(item => item.user_id === user._id);
     const validUserReservations = userReservations.filter(item => isReservationActive(item));
     return validUserReservations;
-};
-
-export const isReservationActive = (reservation: ReservationItem, now = new Date()) => {
-    if (reservation.recurring) {
-        return true;
-    }
-
-    const reservationEndTime = new Date(reservation.date);
-    reservationEndTime.setHours(reservation.end_time, 0, 0, 0);
-
-    return reservationEndTime > now;
 };
 
 export const getDayName = (date: string) => {


### PR DESCRIPTION
## Summary
- register players as inactive, with club membership optional at signup
- add guarded club selection/leave flows, including inactive-on-join behavior and reservation cleanup
- add inactive-member admin management, including inactive tab filtering, activation/deactivation, and removal from club
- redirect users without a club from reservation/bookings routes to club selection
- allow no-club users to sign in so the select-club redirect flow works

## Testing
- `npm run build` ✅
- no automated test suite is present in this repo
- `npm run lint` is currently blocked by repo config: ESLint 9 expects `eslint.config.*`, but the repo does not provide one

## Verification notes
- reviewed the club-switch path to ensure membership state updates clear cached users/reservations before navigation
- confirmed the API now rejects re-selecting the current club and the UI removes the current club from the dropdown