### PR TITLE
Refactor explicit billing renewal flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project should be documented in this file.
 
+## 0.0.17
+
+### Added
+
+- Added admin email notifications when a billing period is created manually and when renewal creates new billing periods automatically.
+- Added billing REST examples for listing billing periods, manually creating a billing period, and triggering the cron-style renewal flow.
+
+### Changed
+
+- Changed billing renewal from lazy read-time state mutation to an explicit renewal process that runs through the shared `/api/billing` endpoint.
+- Changed billing helpers to separate read-only billing state lookup from renewal processing, making billing reads predictable and side-effect free.
+- Changed renewal processing to catch up clubs across multiple missed billing periods and create one admin notification email per created billing period.
+- Changed the billing endpoint documentation and code comments to clarify why renewal uses `GET /api/billing` with the cron secret in both local and Vercel environments.
+
 ## 0.0.16
 
 ### Added

--- a/PLANS.md
+++ b/PLANS.md
@@ -115,17 +115,21 @@ At renewal time:
 
 ## When Billing State Is Refreshed
 
-The app currently updates billing state lazily when billing-aware data is loaded.
+Billing renewal is now processed explicitly instead of being triggered by reads.
 
-- club loading calls billing-state resolution before returning club billing data
-- `GET /api/billing` also resolves billing state before returning billing periods
-- if the active period has already ended, it is marked as completed at that time
-- the next active period is then created immediately from the previous renewal boundary
+- `GET /api/billing` advances due billing periods for requests authorized with `CRON_SECRET`
+- the renewal trigger intentionally shares the billing endpoint because Vercel cron uses `GET` and the free tier has a tight endpoint limit
+- localhost and production both use the same `GET /api/billing` renewal flow
+- the Vercel cron schedule calls that endpoint once per day with `GET`
+- the endpoint expects `Authorization: Bearer ${CRON_SECRET}`
+- write workflows that depend on current billing state run the renewal processor before applying plan-sensitive changes
+- read endpoints no longer mutate billing state as a side effect
 
-This means there is no separate scheduled billing job today.
+Renewal still keeps the original billing anchor day.
 
-- renewal is applied the next time the relevant club billing state is read
-- period boundaries still stay aligned to their original renewal day
+- expired active periods are marked as completed
+- the next active period is created from the previous renewal boundary
+- missed periods are backfilled in order if processing runs after multiple renewal boundaries
 
 ## Upgrades
 

--- a/api/_utils/_billingPeriods.ts
+++ b/api/_utils/_billingPeriods.ts
@@ -26,6 +26,33 @@ type ResolvedClubBillingState = {
     currentBillingPeriod: BillingPeriodDocument | null;
 }
 
+export type ProcessedClubBillingRenewal = ResolvedClubBillingState & {
+    renewalApplied: boolean;
+    completedPeriodsCount: number;
+    createdPeriodsCount: number;
+    createdPeriods: BillingPeriodDocument[];
+}
+
+export type ProcessedBillingRenewalsSummary = {
+    totalClubsChecked: number;
+    clubsRenewed: number;
+    completedPeriodsCount: number;
+    createdPeriodsCount: number;
+}
+
+export type ProcessedBillingRenewalClub = {
+    club: ClubDocument;
+    currentBillingPeriod: BillingPeriodDocument | null;
+    completedPeriodsCount: number;
+    createdPeriodsCount: number;
+    createdPeriods: BillingPeriodDocument[];
+}
+
+export type ProcessedBillingRenewalsResult = {
+    summary: ProcessedBillingRenewalsSummary;
+    renewedClubs: ProcessedBillingRenewalClub[];
+}
+
 function getDateString(value: Date) {
     const year = value.getFullYear();
     const month = `${value.getMonth() + 1}`.padStart(2, '0');
@@ -146,28 +173,59 @@ export async function createInitialBillingPeriod(
     );
 }
 
-// Resolves the club's current billing state and lazily advances renewals by
-// completing expired periods, updating the club plan state, and creating the
-// next active billing period when needed.
-export async function resolveClubBillingState(
-    clubsCollection: Collection<ClubDocument>,
+export async function getClubBillingState(
     billingPeriodsCollection: Collection<BillingPeriodDocument>,
     club: ClubDocument,
     now = new Date()
 ): Promise<ResolvedClubBillingState> {
     const clubId = club._id?.toString();
+    if (!clubId) {
+        return {
+            club,
+            currentBillingPeriod: null,
+        };
+    }
+
+    const activePeriod = await getActiveBillingPeriod(billingPeriodsCollection, clubId);
+    const currentBillingPeriod = activePeriod && hasFutureBillingPeriodEnd(activePeriod.period_end, now)
+        ? activePeriod
+        : null;
+
+    return {
+        club,
+        currentBillingPeriod,
+    };
+}
+
+export async function processClubBillingRenewal(
+    clubsCollection: Collection<ClubDocument>,
+    billingPeriodsCollection: Collection<BillingPeriodDocument>,
+    club: ClubDocument,
+    now = new Date()
+): Promise<ProcessedClubBillingRenewal> {
+    const clubId = club._id?.toString();
     let resolvedClub = club;
+    let renewalApplied = false;
+    let completedPeriodsCount = 0;
+    let createdPeriodsCount = 0;
+    const createdPeriods: BillingPeriodDocument[] = [];
 
     if (!clubId) {
         return {
             club: resolvedClub,
             currentBillingPeriod: null,
+            renewalApplied,
+            completedPeriodsCount,
+            createdPeriodsCount,
+            createdPeriods,
         };
     }
 
     let activePeriod = await getActiveBillingPeriod(billingPeriodsCollection, clubId);
 
     if (activePeriod && !hasFutureBillingPeriodEnd(activePeriod.period_end, now)) {
+        renewalApplied = true;
+        completedPeriodsCount += 1;
         await updateBillingPeriod(billingPeriodsCollection, activePeriod._id, {
             status: 'completed'
         });
@@ -184,10 +242,25 @@ export async function resolveClubBillingState(
         return {
             club: resolvedClub,
             currentBillingPeriod: activePeriod,
+            renewalApplied,
+            completedPeriodsCount,
+            createdPeriodsCount,
+            createdPeriods,
         };
     }
 
     const latestPeriod = await getLatestBillingPeriod(billingPeriodsCollection, clubId);
+    if (!latestPeriod) {
+        return {
+            club: resolvedClub,
+            currentBillingPeriod: null,
+            renewalApplied,
+            completedPeriodsCount,
+            createdPeriodsCount,
+            createdPeriods,
+        };
+    }
+
     let nextStartDate = latestPeriod?.period_end
         ? new Date(`${latestPeriod.period_end}T12:00:00`)
         : now;
@@ -207,17 +280,72 @@ export async function resolveClubBillingState(
         );
 
         if (hasFutureBillingPeriodEnd(nextPeriod.period_end, now)) {
+            renewalApplied = true;
+            createdPeriodsCount += 1;
             const insertedPeriod = await insertBillingPeriod(billingPeriodsCollection, nextPeriod);
+            createdPeriods.push(insertedPeriod);
             return {
                 club: resolvedClub,
                 currentBillingPeriod: insertedPeriod,
+                renewalApplied,
+                completedPeriodsCount,
+                createdPeriodsCount,
+                createdPeriods,
             };
         }
 
-        await insertBillingPeriod(billingPeriodsCollection, {
+        renewalApplied = true;
+        completedPeriodsCount += 1;
+        createdPeriodsCount += 1;
+        const insertedCompletedPeriod = await insertBillingPeriod(billingPeriodsCollection, {
             ...nextPeriod,
             status: 'completed'
         });
+        createdPeriods.push(insertedCompletedPeriod);
         nextStartDate = new Date(`${nextPeriod.period_end}T12:00:00`);
     }
+}
+
+export async function processBillingRenewals(
+    clubsCollection: Collection<ClubDocument>,
+    billingPeriodsCollection: Collection<BillingPeriodDocument>,
+    now = new Date()
+): Promise<ProcessedBillingRenewalsResult> {
+    const clubs = await clubsCollection.find({}).toArray();
+    const summary: ProcessedBillingRenewalsSummary = {
+        totalClubsChecked: clubs.length,
+        clubsRenewed: 0,
+        completedPeriodsCount: 0,
+        createdPeriodsCount: 0,
+    };
+    const renewedClubs: ProcessedBillingRenewalClub[] = [];
+
+    for (const club of clubs) {
+        const result = await processClubBillingRenewal(
+            clubsCollection,
+            billingPeriodsCollection,
+            club,
+            now
+        );
+
+        if (!result.renewalApplied) {
+            continue;
+        }
+
+        summary.clubsRenewed += 1;
+        summary.completedPeriodsCount += result.completedPeriodsCount;
+        summary.createdPeriodsCount += result.createdPeriodsCount;
+        renewedClubs.push({
+            club: result.club,
+            currentBillingPeriod: result.currentBillingPeriod,
+            completedPeriodsCount: result.completedPeriodsCount,
+            createdPeriodsCount: result.createdPeriodsCount,
+            createdPeriods: result.createdPeriods,
+        });
+    }
+
+    return {
+        summary,
+        renewedClubs,
+    };
 }

--- a/api/_utils/_config.ts
+++ b/api/_utils/_config.ts
@@ -3,11 +3,13 @@ const jwtSecret = process.env.jwtSecret;
 const environment = process.env.environment;
 const database_uri = process.env.db_uri;
 const plan_limit = process.env.MEMBERS_LIMIT;
+const cron_secret = process.env.CRON_SECRET;
 
 export {
     database_name,
     jwtSecret,
     environment,
     database_uri,
-    plan_limit
+    plan_limit,
+    cron_secret
 };

--- a/api/billing.ts
+++ b/api/billing.ts
@@ -1,11 +1,12 @@
 import { Collection, MongoClient, ObjectId } from 'mongodb';
-import { database_uri, database_name } from './_utils/_config.js';
-import { sanitize } from './_utils/_lib.js';
+import { cron_secret, database_uri, database_name } from './_utils/_config.js';
+import { sanitize, escapeHtml } from './_utils/_lib.js';
 import { getJwtPayload } from './verifyAuth.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { DBUser, PlanType } from '../src/types.js';
-import { ClubDocument } from './_utils/_types.js';
-import { BillingPeriodDocument, BillingPeriodStatus, resolveClubBillingState } from './_utils/_billingPeriods.js';
+import sendEmail from './_utils/_sendEmail.js';
+import { AdminEmailDocument, ClubDocument } from './_utils/_types.js';
+import { BillingPeriodDocument, BillingPeriodStatus, processBillingRenewals, processClubBillingRenewal } from './_utils/_billingPeriods.js';
 import { getPlanStateAtRenewal } from './_utils/_planTransitions.js';
 
 type BillingBody = {
@@ -61,6 +62,73 @@ function normalizeBillingPeriod(period: BillingPeriodDocument) {
   };
 }
 
+function buildBillingPeriodNotificationEmail(
+  club: Pick<ClubDocument, 'name'>,
+  period: BillingPeriodDocument,
+  notificationType: 'manual' | 'renewal'
+) {
+  const intro = notificationType === 'renewal'
+    ? `Der Abrechnungszeitraum von ${escapeHtml(club.name ?? 'Ihrem Verein')} wurde automatisch verlängert.`
+    : `Für ${escapeHtml(club.name ?? 'Ihren Verein')} wurde ein neuer Abrechnungszeitraum manuell angelegt.`;
+
+  return `
+    <p>${intro}</p>
+    <div style="padding: 10px; background: #f2f2f2;">
+      <table cellspacing="0" style="border-collapse: collapse;">
+        <tbody>
+          <tr><td style="padding: 6px 6px 6px 0;"><strong>Verein</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(club.name ?? '-')}</td></tr>
+          <tr><td style="padding: 6px 6px 6px 0;"><strong>Plan</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.plan_type)}</td></tr>
+          <tr><td style="padding: 6px 6px 6px 0;"><strong>Zeitraum</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.period_start)} bis ${escapeHtml(period.period_end)}</td></tr>
+          <tr><td style="padding: 6px 6px 6px 0;"><strong>Status</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.status)}</td></tr>
+          <tr><td style="padding: 6px 6px 6px 0;"><strong>Quelle</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.source ?? notificationType)}</td></tr>
+        </tbody>
+      </table>
+    </div>
+  `;
+}
+
+async function notifyClubAdminsOfBillingPeriod(
+  database: ReturnType<MongoClient['db']>,
+  clubId: string,
+  subject: string,
+  html: string
+) {
+  const admins = await database.collection<AdminEmailDocument>('users').find({
+    club_id: clubId,
+    role: 'admin',
+    status: 'active',
+  }, {
+    projection: {
+      email: 1,
+    }
+  }).toArray();
+  const adminEmails = admins
+    .map(admin => admin.email?.toLowerCase())
+    .filter((email): email is string => Boolean(email));
+
+  if (!adminEmails.length) {
+    return;
+  }
+
+  await Promise.allSettled(adminEmails.map(email => sendEmail({
+    email,
+    subject,
+    html,
+  })));
+}
+
+// Renewal intentionally lives on GET /api/billing instead of a dedicated route:
+// - Vercel Cron invokes scheduled functions with GET requests
+// - the Vercel free tier endpoint limit makes an extra renewal route expensive
+// - using the same GET branch locally and in production keeps behavior consistent
+function isAuthorizedRenewalRequest(req: VercelRequest) {
+  if (!cron_secret) {
+    return false;
+  }
+
+  return req.method === 'GET' && req.headers.authorization === `Bearer ${cron_secret}`;
+}
+
 if (!database_uri || !database_name) {
   throw new Error('Database configuration is missing');
 }
@@ -74,6 +142,34 @@ export default async (req: VercelRequest, res: VercelResponse) => {
     const users = database.collection<DBUser>('users');
     const clubs = database.collection<ClubDocument>('clubs');
     const billingPeriods = database.collection<BillingPeriodDocument>('billing_periods');
+
+    if (isAuthorizedRenewalRequest(req)) {
+      const { summary, renewedClubs } = await processBillingRenewals(clubs, billingPeriods);
+      await Promise.allSettled(renewedClubs.flatMap(({club, createdPeriods}) => createdPeriods.map(async (period) => {
+        if (!club._id) {
+          return;
+        }
+
+        const subject = `Abrechnungszeitraum automatisch verlängert: ${club.name ?? 'Verein'} (${period.period_start} bis ${period.period_end})`;
+        const html = buildBillingPeriodNotificationEmail(
+          club,
+          period,
+          'renewal'
+        );
+
+        await notifyClubAdminsOfBillingPeriod(
+          database,
+          club._id.toString(),
+          subject,
+          html
+        );
+      })));
+
+      return res.status(200).json({
+        message: 'Billing renewals processed.',
+        data: summary,
+      });
+    }
 
     const payload = await getJwtPayload(req);
     if (!payload) {
@@ -100,13 +196,6 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 
       if (requestedClubId !== requester.club_id) {
         return res.status(403).json({error: 'Reading billing periods for another club is not allowed'});
-      }
-
-      const club = await clubs.findOne({
-        _id: ObjectId.createFromHexString(requestedClubId)
-      });
-      if (club) {
-        await resolveClubBillingState(clubs, billingPeriods, club);
       }
 
       const periods = await billingPeriods.find({
@@ -161,7 +250,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         return res.status(404).json(validationError('/club_id', 'Verein nicht gefunden.'));
       }
 
-      const { club: resolvedClub } = await resolveClubBillingState(clubs, billingPeriods, club);
+      const { club: resolvedClub } = await processClubBillingRenewal(clubs, billingPeriods, club);
 
       const billingPlanType = plan_type ?? resolvedClub.next_plan_type;
 
@@ -198,6 +287,24 @@ export default async (req: VercelRequest, res: VercelResponse) => {
             }
           }
         );
+      }
+
+      try {
+        const subject = `Neuer Abrechnungszeitraum angelegt: ${club.name ?? 'Verein'} (${period.period_start} bis ${period.period_end})`;
+        const html = buildBillingPeriodNotificationEmail(
+          club,
+          period,
+          'manual'
+        );
+
+        await notifyClubAdminsOfBillingPeriod(
+          database,
+          club_id,
+          subject,
+          html
+        );
+      } catch (emailError) {
+        console.error('Failed to notify club admins about billing period creation', emailError);
       }
 
       return res.status(201).json({

--- a/api/clubs.ts
+++ b/api/clubs.ts
@@ -7,7 +7,7 @@ import { ClubWithBilling, DBUser, JwtPayload } from '../src/types.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { ClubDocument, ClubFormBody, CourtsFormBody } from './_utils/_types.js';
 import { updateCourts } from './_utils/_updateCourts.js';
-import { createInitialBillingPeriod, BillingPeriodDocument, isDowngradeLocked, resolveClubBillingState } from './_utils/_billingPeriods.js';
+import { createInitialBillingPeriod, BillingPeriodDocument, getClubBillingState, isDowngradeLocked, processClubBillingRenewal } from './_utils/_billingPeriods.js';
 import { getClubPlanState, getPlanChangeUpdate } from './_utils/_planTransitions.js';
 import { fetchClub } from './_utils/_fetchClub.js';
 import { isLowerPlan } from '../src/planConfig.js';
@@ -28,19 +28,18 @@ const enrichClubWithBilling = async (
     return null;
   }
 
-  const { club, currentBillingPeriod } = await resolveClubBillingState(
-    collection,
+  const { currentBillingPeriod } = await getClubBillingState(
     billingPeriodsCollection,
     doc
   );
 
   return {
-    ...club,
-    _id: club._id.toString(),
+    ...doc,
+    _id: doc._id.toString(),
     current_billing_plan_type: currentBillingPeriod?.plan_type,
     current_billing_period_end: currentBillingPeriod?.period_end,
-    downgrade_locked: isDowngradeLocked(club, currentBillingPeriod),
-    effective_members_limit: getEffectiveMembersLimitForPlan(club.access_plan_type),
+    downgrade_locked: isDowngradeLocked(doc, currentBillingPeriod),
+    effective_members_limit: getEffectiveMembersLimitForPlan(doc.access_plan_type),
     members_limit_override_active: hasMembersLimitOverride(),
   };
 };
@@ -264,7 +263,7 @@ async function updateClub(
   if (!doc) {
     return res.status(404).json({error: 'Club not found'});
   }
-  const { club: resolvedClub, currentBillingPeriod } = await resolveClubBillingState(
+  const { club: resolvedClub, currentBillingPeriod } = await processClubBillingRenewal(
     collection,
     billingPeriodsCollection,
     doc

--- a/api/select-club.ts
+++ b/api/select-club.ts
@@ -7,7 +7,6 @@ import { DBUser, ReservationItem } from '../src/types.js';
 import sendEmail from './_utils/_sendEmail.js';
 import { AdminEmailDocument, ClubDocument } from './_utils/_types.js';
 import { isReservationActive } from '../src/utils/utils.js';
-import { BillingPeriodDocument, resolveClubBillingState } from './_utils/_billingPeriods.js';
 
 type SelectClubBody = {
   club_id?: string;
@@ -125,7 +124,6 @@ export default async (req: VercelRequest, res: VercelResponse) => {
     const userCollection = database.collection<DBUser>('users');
     const clubCollection = database.collection<ClubDocument>('clubs');
     const reservationsCollection = database.collection<ReservationItem>('reservations');
-    const billingPeriodsCollection = database.collection<BillingPeriodDocument>('billing_periods');
 
     if (req.method === 'POST') {
       const body = sanitize(req.body) as SelectClubBody;
@@ -204,12 +202,6 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       if (requester.club_id === club_id) {
         return res.status(409).json(validationError('Sie sind diesem Verein bereits zugeordnet.'));
       }
-
-      await resolveClubBillingState(
-        clubCollection,
-        billingPeriodsCollection,
-        club
-      );
 
       if (previousClubId && previousClubId !== club_id) {
         await deleteActiveReservationsForUser(reservationsCollection, payload._id, previousClubId);

--- a/api/signup.ts
+++ b/api/signup.ts
@@ -9,7 +9,6 @@ import { database_uri, database_name } from './_utils/_config.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { createError, getErrorCause, getErrorMessage } from './_utils/_errors.js';
 import { AdminEmailDocument, ClubDocument } from './_utils/_types.js';
-import { BillingPeriodDocument, resolveClubBillingState } from './_utils/_billingPeriods.js';
 
 type SignupBody = {
     first_name: string;
@@ -177,12 +176,6 @@ export default async (req: VercelRequest, res: VercelResponse) => {
                     if (!club) {
                         throw createError('Der ausgewählte Verein existiert nicht.', 'club_id');
                     }
-
-                    await resolveClubBillingState(
-                        database.collection<ClubDocument>('clubs'),
-                        database.collection<BillingPeriodDocument>('billing_periods'),
-                        club
-                    );
                 }
 
                 await addUser(database, user);

--- a/api/users.ts
+++ b/api/users.ts
@@ -8,7 +8,7 @@ import { escapeHtml } from './_utils/_lib.js';
 import { ReservationItem } from '../src/types.js';
 import { ClubDocument } from './_utils/_types.js';
 import { isReservationActive } from '../src/utils/utils.js';
-import { BillingPeriodDocument, resolveClubBillingState } from './_utils/_billingPeriods.js';
+import { BillingPeriodDocument, processClubBillingRenewal } from './_utils/_billingPeriods.js';
 import { getEffectiveMembersLimitForPlan } from './_utils/_planLimits.js';
 
 function isString(value: unknown): value is string {
@@ -193,7 +193,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         _id: ObjectId.createFromHexString(requester.club_id)
       }) : null;
       const billingState = requester.club_id && club
-        ? await resolveClubBillingState(clubCollection, billingPeriodsCollection, club)
+        ? await processClubBillingRenewal(clubCollection, billingPeriodsCollection, club)
         : null;
       const resolvedClub = billingState?.club ?? club;
       const currentBillingPeriod = billingState?.currentBillingPeriod ?? null;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "abzumplatz",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/rest/billing.rest
+++ b/rest/billing.rest
@@ -1,3 +1,15 @@
+// list billing periods for the logged-in admin's club
+GET http://localhost:3000/api/billing
+Authorization: Bearer <token>
+
+###
+
+// notes:
+// - with a normal admin JWT, GET /api/billing returns billing periods
+// - you can optionally add ?club_id=<club-id>, but only for the same admin club
+
+###
+
 // insert an active billing period
 POST http://localhost:3000/api/billing
 Content-Type: application/json
@@ -17,3 +29,30 @@ Authorization: Bearer <token>
 // - period_end is the next renewal boundary
 // - the derived user-facing "bezahlt bis" date for this example would be 2026-07-16
 // - make sure there is no other active billing period for the same club before inserting
+
+###
+
+// trigger billing renewals with the cron secret
+// this uses GET on purpose because Vercel cron invokes functions with GET
+// and we keep it on /api/billing to avoid spending an extra endpoint on free tier
+GET http://localhost:3000/api/billing
+Authorization: Bearer <cron-secret>
+
+###
+
+// expected response shape for the renewal trigger:
+// {
+//   "message": "Billing renewals processed.",
+//   "data": {
+//     "totalClubsChecked": 1,
+//     "clubsRenewed": 0,
+//     "completedPeriodsCount": 0,
+//     "createdPeriodsCount": 0
+//   }
+// }
+//
+// notes:
+// - use CRON_SECRET here, not the normal admin JWT
+// - with CRON_SECRET, GET /api/billing runs the renewal job instead of returning billing periods
+// - without CRON_SECRET, GET /api/billing behaves as the normal admin billing list endpoint
+// - this only creates a new billing period if a club's active period is already due

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+    "crons": [
+        {"path": "/api/billing", "schedule": "0 3 * * *"}
+    ],
     "rewrites": [
         {"source": "/admin", "destination": "/"},
         {"source": "/admin/members", "destination": "/"},


### PR DESCRIPTION
## Summary
- move billing renewal from lazy read-time mutation to an explicit renewal flow
- keep renewal on the shared `/api/billing` endpoint for Vercel cron compatibility and endpoint-count limits
- add admin notifications for manual billing creation and automatic renewal-created billing periods
- add/update billing documentation and REST examples for listing, manual creation, and cron-triggered renewal

## Why
Billing state was previously advanced as a side effect of read paths. This made read behavior less predictable and tied renewal to whichever endpoint happened to load billing-aware data first. The new flow makes renewal explicit and keeps reads side-effect free.

## Impact
- billing renewal is now triggered explicitly instead of during reads
- `GET /api/billing` behaves differently depending on auth context: admin JWT lists billing periods, cron-secret auth runs renewal
- automatic catch-up renewal can create multiple missed billing periods, and admins receive one email per created period
- release notes are split so this work lands under `0.0.17`

## Validation
- `npm run build`

## Related
- Closes #104