### PR TITLE
Add billing invoice emails and resend support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project should be documented in this file.
 
+## 0.0.18
+
+### Added
+
+- Added invoice-style admin email content for billing periods, including VAT display, club address details, bank transfer instructions, and stable invoice references.
+- Added an admin action to resend the invoice email for a billing period from the billing list in the admin UI.
+- Added a backfill script for billing-period prices so older billing documents can be migrated to the new price snapshot model.
+
+### Changed
+
+- Changed billing periods to store a required `price` snapshot that is used as the invoice source of truth.
+- Changed the admin billing list to show billing-period prices and clearer invoice resend status messages.
+- Changed invoice delivery handling so API responses clearly distinguish between a created billing period and a failed invoice email delivery.
+- Changed `api/billing.ts` to delegate invoice rendering and delivery work to a dedicated billing-invoice helper, keeping the endpoint logic smaller and easier to maintain.
+
 ## 0.0.17
 
 ### Added
@@ -15,6 +30,8 @@ All notable changes to this project should be documented in this file.
 - Changed billing helpers to separate read-only billing state lookup from renewal processing, making billing reads predictable and side-effect free.
 - Changed renewal processing to catch up clubs across multiple missed billing periods and create one admin notification email per created billing period.
 - Changed the billing endpoint documentation and code comments to clarify why renewal uses `GET /api/billing` with the cron secret in both local and Vercel environments.
+- Changed billing period price handling so `price` is now required in the shared billing types and invoice generation fails loudly if a malformed billing record is missing its stored price.
+- Changed billing invoice delivery to report failures back to the caller instead of silently swallowing admin email delivery errors.
 
 ## 0.0.16
 

--- a/PLANS.md
+++ b/PLANS.md
@@ -48,6 +48,7 @@ Each billing period stores:
 
 - `club_id`
 - `plan_type`
+- `price`
 - `period_start`
 - `period_end`
 - `status`
@@ -177,7 +178,8 @@ Invoices are based on whole billing periods.
 
 - one invoice covers one full billing period
 - invoices are not split because of a mid-period plan change
-- the invoice for the current period is based on that period’s plan
+- the invoice for the current period is based on that billing period document
+- each billing period stores the plan price snapshot that applied when that period was created
 - the next invoice uses the plan that becomes effective at renewal
 
 ## Member Limits

--- a/api/_utils/_billingInvoices.ts
+++ b/api/_utils/_billingInvoices.ts
@@ -1,0 +1,219 @@
+import { Db } from 'mongodb';
+import { getCoveredUntilFromPeriodEnd, getPlanName } from '../../src/planConfig.js';
+import { bank_account_holder, bank_iban, bank_name } from './_config.js';
+import { escapeHtml } from './_lib.js';
+import sendEmail from './_sendEmail.js';
+import { BillingPeriodDocument } from './_billingPeriods.js';
+import { AdminEmailDocument, ClubDocument } from './_types.js';
+
+export type BillingInvoiceNotificationType = 'manual' | 'renewal' | 'resend';
+
+function parseLocalDate(dateString: string) {
+  return new Date(`${dateString}T12:00:00`);
+}
+
+export function getRequiredBillingPrice(period: Pick<BillingPeriodDocument, '_id' | 'club_id' | 'period_start' | 'price'>) {
+  if (!Number.isFinite(period.price)) {
+    const reference = period._id?.toString() ?? `${period.club_id}:${period.period_start}`;
+    throw new Error(`Billing period ${reference} is missing a valid price.`);
+  }
+
+  return period.price;
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(value);
+}
+
+function getIncludedVatAmount(value: number, vatRate = 0.19) {
+  return value * vatRate / (1 + vatRate);
+}
+
+function getNetAmount(value: number, vatRate = 0.19) {
+  return value / (1 + vatRate);
+}
+
+function formatDate(value: string | Date) {
+  const date = typeof value === 'string' ? parseLocalDate(value) : value;
+  return date.toLocaleDateString('de-DE');
+}
+
+function buildClubAddressLines(club: Pick<ClubDocument, 'address_line1' | 'postal_code' | 'city' | 'country'>) {
+  const cityLine = [club.postal_code, club.city].filter(Boolean).join(' ');
+
+  return [
+    club.address_line1,
+    cityLine || undefined,
+  ].filter((line): line is string => Boolean(line));
+}
+
+export function getBillingInvoiceReference(clubId: string, period: BillingPeriodDocument) {
+  const periodKey = period.period_start.replaceAll('-', '');
+  const clubKey = clubId.slice(-6).toUpperCase();
+  const idKey = period._id?.toString().slice(-6).toUpperCase();
+
+  return ['AZP', clubKey, periodKey, idKey].filter(Boolean).join('-');
+}
+
+function buildBillingPeriodNotificationEmail(
+  club: Pick<ClubDocument, '_id' | 'name' | 'address_line1' | 'postal_code' | 'city' | 'country'>,
+  period: BillingPeriodDocument,
+  notificationType: BillingInvoiceNotificationType
+) {
+  const clubId = club._id?.toString() ?? period.club_id;
+  const price = getRequiredBillingPrice(period);
+  const invoiceReference = getBillingInvoiceReference(clubId, period);
+  const coveredUntil = getCoveredUntilFromPeriodEnd(period.period_end) ?? period.period_end;
+  const issueDate = formatDate(period.created_at);
+  const serviceStart = formatDate(period.period_start);
+  const serviceEnd = formatDate(coveredUntil);
+  const planName = getPlanName(period.plan_type);
+  const amountLabel = formatCurrency(price);
+  const netAmountLabel = formatCurrency(getNetAmount(price));
+  const vatLabel = formatCurrency(getIncludedVatAmount(price));
+  const clubAddressLines = buildClubAddressLines(club);
+  const hasBankDetails = Boolean(bank_iban && bank_name && bank_account_holder);
+  const note = notificationType === 'renewal'
+    ? 'Dieser Abrechnungszeitraum wurde automatisch bei der Verlängerung Ihres Plans angelegt.'
+    : notificationType === 'resend'
+      ? 'Diese Rechnung wurde auf Anfrage erneut versendet.'
+      : 'Dieser Abrechnungszeitraum wurde manuell angelegt.';
+
+  return `
+    <div style="font-family: Arial, sans-serif; color: #111827; line-height: 1.5; max-width: 720px;">
+      <table cellspacing="0" cellpadding="0" style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+        <tbody>
+          <tr>
+            <td style="vertical-align: top;">
+              <div style="font-size: 28px; font-weight: 700; letter-spacing: 0.02em;">Rechnung</div>
+              <div style="color: #4b5563;">Abzumplatz | Denzlingerstr. 20, 79108 Freiburg im Breisgau</div>
+            </td>
+            <td style="vertical-align: top; text-align: right;">
+              <div><strong>Rechnungsnr.</strong> ${escapeHtml(invoiceReference)}</div>
+              <div><strong>Rechnungsdatum</strong> ${escapeHtml(issueDate)}</div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div style="margin-bottom: 24px;">
+        <div style="font-size: 16px;">${escapeHtml(club.name ?? 'Verein')}</div>
+        ${clubAddressLines.map(line => `<div style="font-size: 17px;">${escapeHtml(line)}</div>`).join('')}
+      </div>
+
+      <table cellspacing="0" cellpadding="0" style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+        <thead>
+          <tr>
+            <th style="text-align: left; padding: 10px 0; border-bottom: 2px solid #d1d5db;">Leistung</th>
+            <th style="text-align: left; padding: 10px 0; border-bottom: 2px solid #d1d5db;">Zeitraum</th>
+            <th style="text-align: right; padding: 10px 0; border-bottom: 2px solid #d1d5db;">Betrag</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="padding: 12px 0; border-bottom: 1px solid #e5e7eb;">${escapeHtml(planName)} Plan</td>
+            <td style="padding: 12px 0; border-bottom: 1px solid #e5e7eb;">
+              ${escapeHtml(serviceStart)} - ${escapeHtml(serviceEnd)}
+            </td>
+            <td style="padding: 12px 0; border-bottom: 1px solid #e5e7eb; text-align: right;">
+              ${escapeHtml(amountLabel)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table cellspacing="0" cellpadding="0" style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+        <tbody>
+          <tr>
+            <td style="padding: 6px 0;"><strong>Nettobetrag</strong></td>
+            <td style="padding: 6px 0; text-align: right;">${escapeHtml(netAmountLabel)}</td>
+          </tr>
+          <tr>
+            <td style="padding: 6px 0;"><strong>Umsatzsteuer (19%)</strong></td>
+            <td style="padding: 6px 0; text-align: right;">${escapeHtml(vatLabel)}</td>
+          </tr>
+          <tr>
+            <td style="padding: 6px 0; font-size: 20px;"><strong>Rechnungsbetrag</strong></td>
+            <td style="padding: 6px 0; text-align: right; font-size: 20px;"><strong>${escapeHtml(amountLabel)}</strong></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p style="margin: 0 0 10px 0;">${escapeHtml(note)}</p>
+      ${hasBankDetails ? `
+        <div style="margin: 20px 0 10px 0; padding: 16px; background: #f9fafb; border: 1px solid #e5e7eb;">
+          <div style="font-size: 13px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 8px;">Zahlungshinweis</div>
+          <p style="margin: 0 0 10px 0;">Bitte überweisen Sie den Rechnungsbetrag unter Angabe der Rechnungsnr. ${escapeHtml(invoiceReference)} auf folgendes Konto:</p>
+          <table cellspacing="0" cellpadding="0" style="border-collapse: collapse;">
+            <tbody>
+              <tr><td style="padding: 4px 12px 4px 0;"><strong>Kontoinhaber</strong></td><td style="padding: 4px 0;">${escapeHtml(bank_account_holder ?? '-')}</td></tr>
+              <tr><td style="padding: 4px 12px 4px 0;"><strong>Bank</strong></td><td style="padding: 4px 0;">${escapeHtml(bank_name ?? '-')}</td></tr>
+              <tr><td style="padding: 4px 12px 4px 0;"><strong>IBAN</strong></td><td style="padding: 4px 0;">${escapeHtml(bank_iban ?? '-')}</td></tr>
+            </tbody>
+          </table>
+        </div>
+      ` : ''}
+      <p style="margin: 0; color: #6b7280; font-size: 13px;">Diese E-Mail dient aktuell als Rechnungsbeleg für den gespeicherten Abrechnungszeitraum.</p>
+    </div>
+  `;
+}
+
+async function notifyClubAdminsOfBillingPeriod(
+  database: Db,
+  clubId: string,
+  subject: string,
+  html: string
+) {
+  const admins = await database.collection<AdminEmailDocument>('users').find({
+    club_id: clubId,
+    role: 'admin',
+    status: 'active',
+  }, {
+    projection: {
+      email: 1,
+    }
+  }).toArray();
+  const adminEmails = admins
+    .map(admin => admin.email?.toLowerCase())
+    .filter((email): email is string => Boolean(email));
+
+  if (!adminEmails.length) {
+    throw new Error('Invoice email delivery failed because no active admin email recipients were found.');
+  }
+
+  const results = await Promise.allSettled(adminEmails.map(email => sendEmail({
+    email,
+    subject,
+    html,
+  })));
+
+  const failedDeliveries = results.filter((result) => result.status === 'rejected');
+  if (failedDeliveries.length) {
+    throw new Error(`Invoice email delivery failed for ${failedDeliveries.length} of ${adminEmails.length} admin recipient(s).`);
+  }
+}
+
+export async function sendBillingPeriodInvoiceEmail(
+  database: Db,
+  club: Pick<ClubDocument, '_id' | 'name' | 'address_line1' | 'postal_code' | 'city' | 'country'>,
+  period: BillingPeriodDocument,
+  notificationType: BillingInvoiceNotificationType
+) {
+  const clubId = club._id?.toString() ?? period.club_id;
+  const subject = `Rechnung ${getBillingInvoiceReference(clubId, period)} für ${club.name ?? 'Verein'}`;
+  const html = buildBillingPeriodNotificationEmail(
+    club,
+    period,
+    notificationType
+  );
+
+  await notifyClubAdminsOfBillingPeriod(
+    database,
+    clubId,
+    subject,
+    html
+  );
+}

--- a/api/_utils/_billingInvoices.ts
+++ b/api/_utils/_billingInvoices.ts
@@ -203,7 +203,8 @@ export async function sendBillingPeriodInvoiceEmail(
   notificationType: BillingInvoiceNotificationType
 ) {
   const clubId = club._id?.toString() ?? period.club_id;
-  const subject = `Rechnung ${getBillingInvoiceReference(clubId, period)} für ${club.name ?? 'Verein'}`;
+  const coveredUntil = getCoveredUntilFromPeriodEnd(period.period_end) ?? period.period_end;
+  const subject = `Rechnung für ${club.name ?? 'Verein'} (${formatDate(period.period_start)} - ${formatDate(coveredUntil)})`;
   const html = buildBillingPeriodNotificationEmail(
     club,
     period,

--- a/api/_utils/_billingPeriods.ts
+++ b/api/_utils/_billingPeriods.ts
@@ -1,6 +1,6 @@
 import { Collection, ObjectId } from 'mongodb';
 import { PlanType } from '../../src/types.js';
-import { getNextBillingPeriodStartForPlan, hasFutureBillingPeriodEnd } from '../../src/planConfig.js';
+import { getNextBillingPeriodStartForPlan, getPlanPrice, hasFutureBillingPeriodEnd } from '../../src/planConfig.js';
 import { ClubDocument } from './_types.js';
 import {
     getPlanStateAtRenewal,
@@ -13,6 +13,7 @@ export type BillingPeriodDocument = {
     _id?: ObjectId;
     club_id: string;
     plan_type: PlanType;
+    price: number;
     anchor_day: number;
     period_start: string;
     period_end: string;
@@ -71,6 +72,7 @@ function createBillingPeriodRecord(
     return {
         club_id: clubId,
         plan_type: planType,
+        price: getPlanPrice(planType),
         anchor_day: anchorDay,
         period_start: getDateString(startDate),
         period_end: getNextBillingPeriodStartForPlan(planType, startDate, anchorDay)!,
@@ -84,7 +86,8 @@ async function insertBillingPeriod(
     collection: Collection<BillingPeriodDocument>,
     period: BillingPeriodDocument
 ) {
-    await collection.insertOne(period);
+    const result = await collection.insertOne(period);
+    period._id = result.insertedId;
     return period;
 }
 

--- a/api/_utils/_config.ts
+++ b/api/_utils/_config.ts
@@ -4,8 +4,14 @@ const environment = process.env.environment;
 const database_uri = process.env.db_uri;
 const plan_limit = process.env.MEMBERS_LIMIT;
 const cron_secret = process.env.CRON_SECRET;
+const bank_iban = process.env.BANK_IBAN;
+const bank_name = process.env.BANK_NAME;
+const bank_account_holder = process.env.BANK_ACCOUNT_HOLDER;
 
 export {
+    bank_account_holder,
+    bank_iban,
+    bank_name,
     database_name,
     jwtSecret,
     environment,

--- a/api/billing.ts
+++ b/api/billing.ts
@@ -1,15 +1,18 @@
-import { Collection, MongoClient, ObjectId } from 'mongodb';
+import { MongoClient, ObjectId } from 'mongodb';
 import { cron_secret, database_uri, database_name } from './_utils/_config.js';
-import { sanitize, escapeHtml } from './_utils/_lib.js';
+import { sanitize } from './_utils/_lib.js';
 import { getJwtPayload } from './verifyAuth.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { DBUser, PlanType } from '../src/types.js';
-import sendEmail from './_utils/_sendEmail.js';
-import { AdminEmailDocument, ClubDocument } from './_utils/_types.js';
+import { ClubDocument } from './_utils/_types.js';
 import { BillingPeriodDocument, BillingPeriodStatus, processBillingRenewals, processClubBillingRenewal } from './_utils/_billingPeriods.js';
 import { getPlanStateAtRenewal } from './_utils/_planTransitions.js';
+import { getPlanPrice } from '../src/planConfig.js';
+import { getRequiredBillingPrice, sendBillingPeriodInvoiceEmail } from './_utils/_billingInvoices.js';
 
 type BillingBody = {
+  action?: 'create_period' | 'send_invoice';
+  billing_period_id?: string;
   club_id?: string;
   plan_type?: PlanType;
   anchor_day?: number;
@@ -58,63 +61,9 @@ function isValidDateOnlyString(value: string) {
 function normalizeBillingPeriod(period: BillingPeriodDocument) {
   return {
     ...period,
+    price: getRequiredBillingPrice(period),
     _id: period._id?.toString(),
   };
-}
-
-function buildBillingPeriodNotificationEmail(
-  club: Pick<ClubDocument, 'name'>,
-  period: BillingPeriodDocument,
-  notificationType: 'manual' | 'renewal'
-) {
-  const intro = notificationType === 'renewal'
-    ? `Der Abrechnungszeitraum von ${escapeHtml(club.name ?? 'Ihrem Verein')} wurde automatisch verlängert.`
-    : `Für ${escapeHtml(club.name ?? 'Ihren Verein')} wurde ein neuer Abrechnungszeitraum manuell angelegt.`;
-
-  return `
-    <p>${intro}</p>
-    <div style="padding: 10px; background: #f2f2f2;">
-      <table cellspacing="0" style="border-collapse: collapse;">
-        <tbody>
-          <tr><td style="padding: 6px 6px 6px 0;"><strong>Verein</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(club.name ?? '-')}</td></tr>
-          <tr><td style="padding: 6px 6px 6px 0;"><strong>Plan</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.plan_type)}</td></tr>
-          <tr><td style="padding: 6px 6px 6px 0;"><strong>Zeitraum</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.period_start)} bis ${escapeHtml(period.period_end)}</td></tr>
-          <tr><td style="padding: 6px 6px 6px 0;"><strong>Status</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.status)}</td></tr>
-          <tr><td style="padding: 6px 6px 6px 0;"><strong>Quelle</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(period.source ?? notificationType)}</td></tr>
-        </tbody>
-      </table>
-    </div>
-  `;
-}
-
-async function notifyClubAdminsOfBillingPeriod(
-  database: ReturnType<MongoClient['db']>,
-  clubId: string,
-  subject: string,
-  html: string
-) {
-  const admins = await database.collection<AdminEmailDocument>('users').find({
-    club_id: clubId,
-    role: 'admin',
-    status: 'active',
-  }, {
-    projection: {
-      email: 1,
-    }
-  }).toArray();
-  const adminEmails = admins
-    .map(admin => admin.email?.toLowerCase())
-    .filter((email): email is string => Boolean(email));
-
-  if (!adminEmails.length) {
-    return;
-  }
-
-  await Promise.allSettled(adminEmails.map(email => sendEmail({
-    email,
-    subject,
-    html,
-  })));
 }
 
 // Renewal intentionally lives on GET /api/billing instead of a dedicated route:
@@ -145,25 +94,35 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 
     if (isAuthorizedRenewalRequest(req)) {
       const { summary, renewedClubs } = await processBillingRenewals(clubs, billingPeriods);
-      await Promise.allSettled(renewedClubs.flatMap(({club, createdPeriods}) => createdPeriods.map(async (period) => {
+      const invoiceDeliveries = await Promise.allSettled(renewedClubs.flatMap(({club, createdPeriods}) => createdPeriods.map(async (period) => {
         if (!club._id) {
           return;
         }
 
-        const subject = `Abrechnungszeitraum automatisch verlängert: ${club.name ?? 'Verein'} (${period.period_start} bis ${period.period_end})`;
-        const html = buildBillingPeriodNotificationEmail(
+        await sendBillingPeriodInvoiceEmail(
+          database,
           club,
           period,
           'renewal'
         );
-
-        await notifyClubAdminsOfBillingPeriod(
-          database,
-          club._id.toString(),
-          subject,
-          html
-        );
       })));
+
+      const failedInvoiceDeliveries = invoiceDeliveries.filter((result) => result.status === 'rejected');
+      if (failedInvoiceDeliveries.length) {
+        failedInvoiceDeliveries.forEach((result) => {
+          if (result.status === 'rejected') {
+            console.error('Failed to send renewal invoice email', result.reason);
+          }
+        });
+
+        return res.status(502).json({
+          error: 'Billing renewals were processed, but one or more invoice emails could not be delivered.',
+          data: {
+            ...summary,
+            failed_invoice_deliveries: failedInvoiceDeliveries.length,
+          },
+        });
+      }
 
       return res.status(200).json({
         message: 'Billing renewals processed.',
@@ -210,6 +169,8 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 
     if (req.method === 'POST') {
       const body = sanitize(req.body) as BillingBody;
+      const action = body.action ?? 'create_period';
+      const billing_period_id = isString(body.billing_period_id) ? body.billing_period_id : undefined;
       const club_id = isString(body.club_id) ? body.club_id : undefined;
       const plan_type = isString(body.plan_type) ? body.plan_type as PlanType : undefined;
       const anchor_day = typeof body.anchor_day === 'number' ? body.anchor_day : undefined;
@@ -217,6 +178,60 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       const period_end = isString(body.period_end) ? body.period_end : undefined;
       const status = body.status ?? 'active';
       const source = isString(body.source) ? body.source : undefined;
+
+      if (action === 'send_invoice') {
+        if (!billing_period_id) {
+          return res.status(400).json(validationError('/billing_period_id', 'Bitte geben Sie eine Abrechnungs-ID an.'));
+        }
+        if (!isObjectIdString(billing_period_id)) {
+          return res.status(400).json(validationError('/billing_period_id', 'Bitte geben Sie eine gültige Abrechnungs-ID an.'));
+        }
+
+        const period = await billingPeriods.findOne({
+          _id: ObjectId.createFromHexString(billing_period_id),
+        });
+        if (!period) {
+          return res.status(404).json(validationError('/billing_period_id', 'Abrechnungszeitraum nicht gefunden.'));
+        }
+        if (period.club_id !== requester.club_id) {
+          return res.status(403).json({error: 'Reading billing periods for another club is not allowed'});
+        }
+
+        const club = await clubs.findOne({
+          _id: ObjectId.createFromHexString(period.club_id),
+        });
+        if (!club) {
+          return res.status(404).json({error: 'Club not found for billing period'});
+        }
+
+        try {
+          await sendBillingPeriodInvoiceEmail(
+            database,
+            club,
+            period,
+            'resend'
+          );
+        } catch (emailError) {
+          console.error('Failed to resend invoice email', emailError);
+          const detail = emailError instanceof Error
+            ? ` ${emailError.message}`
+            : '';
+          return res.status(502).json({
+            error: `Die Rechnung wurde bereits erstellt, aber die E-Mail konnte nicht zugestellt werden.${detail}`,
+            data: {
+              _id: period._id?.toString(),
+              club_id: period.club_id,
+              period_start: period.period_start,
+              period_end: period.period_end,
+            },
+          });
+        }
+
+        return res.status(200).json({
+          message: 'Invoice email sent.',
+          data: normalizeBillingPeriod(period),
+        });
+      }
 
       if (!club_id) {
         return res.status(400).json(validationError('/club_id', 'Bitte geben Sie eine Vereins-ID an.'));
@@ -267,6 +282,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       const period: BillingPeriodDocument = {
         club_id,
         plan_type: billingPlanType,
+        price: getPlanPrice(billingPlanType),
         anchor_day: anchor_day ?? startDate.getDate(),
         period_start,
         period_end,
@@ -276,6 +292,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       };
 
       const insertResult = await billingPeriods.insertOne(period);
+      period._id = insertResult.insertedId;
 
       if (status === 'active') {
         await clubs.updateOne(
@@ -290,21 +307,21 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       }
 
       try {
-        const subject = `Neuer Abrechnungszeitraum angelegt: ${club.name ?? 'Verein'} (${period.period_start} bis ${period.period_end})`;
-        const html = buildBillingPeriodNotificationEmail(
+        await sendBillingPeriodInvoiceEmail(
+          database,
           club,
           period,
           'manual'
         );
-
-        await notifyClubAdminsOfBillingPeriod(
-          database,
-          club_id,
-          subject,
-          html
-        );
       } catch (emailError) {
-        console.error('Failed to notify club admins about billing period creation', emailError);
+        console.error('Failed to send invoice email for manually created billing period', emailError);
+        const detail = emailError instanceof Error
+          ? ` ${emailError.message}`
+          : '';
+        return res.status(502).json({
+          error: `Der Abrechnungszeitraum wurde angelegt, aber die Rechnungs-E-Mail konnte nicht zugestellt werden.${detail}`,
+          data: normalizeBillingPeriod(period),
+        });
       }
 
       return res.status(201).json({
@@ -312,7 +329,6 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         data: {
           ...normalizeBillingPeriod({
             ...period,
-            _id: insertResult.insertedId,
           })
         }
       });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "abzumplatz",
   "private": true,
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,6 +9,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "export:db": "node scripts/export-mongodb.js",
+    "backfill:billing-prices": "node scripts/backfill-billing-period-prices.js",
     "release:github": "node scripts/release-github.js"
   },
   "dependencies": {

--- a/scripts/backfill-billing-period-prices.js
+++ b/scripts/backfill-billing-period-prices.js
@@ -1,0 +1,58 @@
+import process from 'node:process';
+import dotenv from 'dotenv';
+import { MongoClient } from 'mongodb';
+
+dotenv.config({ quiet: true });
+const DEFAULT_DATABASE_NAME = 'abzumplatz';
+
+const PRICE_BY_PLAN = {
+  basic: 0,
+  pro: 10,
+  elite: 25,
+};
+
+async function main() {
+  const uri = process.env.db_uri;
+  const dbName = process.env.db_name || DEFAULT_DATABASE_NAME;
+
+  if (!uri) {
+    throw new Error('Missing db_uri. Add it to .env or your environment.');
+  }
+
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    const collection = client.db(dbName).collection('billing_periods');
+    let updatedCount = 0;
+
+    for (const [planType, price] of Object.entries(PRICE_BY_PLAN)) {
+      const result = await collection.updateMany(
+        {
+          plan_type: planType,
+          $or: [
+            { price: { $exists: false } },
+            { price: null },
+          ],
+        },
+        {
+          $set: {
+            price,
+          },
+        }
+      );
+
+      updatedCount += result.modifiedCount;
+      console.log(`Updated ${result.modifiedCount} ${planType} billing period(s) to price ${price}.`);
+    }
+
+    console.log(`Done. Updated ${updatedCount} billing period(s) in total.`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/src/app.css
+++ b/src/app.css
@@ -348,3 +348,13 @@ ul {
 .billings-table .billings-table__period {
     padding-right: 1.25rem;
 }
+
+.billings-table th,
+.billings-table td {
+    vertical-align: middle;
+}
+
+.billings-table button {
+    margin-top: 0;
+    padding: 0;
+}

--- a/src/pages/admin/Billings.tsx
+++ b/src/pages/admin/Billings.tsx
@@ -8,15 +8,25 @@ function parseLocalDate(dateString: string) {
     return new Date(`${dateString}T12:00:00`);
 }
 
+function formatCurrency(value: number) {
+    return new Intl.NumberFormat('de-DE', {
+        style: 'currency',
+        currency: 'EUR',
+    }).format(value);
+}
+
 export default function AdminBillingsPage() {
     const [loading, setLoading] = useState(false);
     const [billings, setBillings] = useState<BillingPeriod[]>([]);
-    const [error, setError] = useState<string | null>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [invoiceError, setInvoiceError] = useState<string | null>(null);
+    const [invoiceMessage, setInvoiceMessage] = useState<string | null>(null);
+    const [sendingInvoiceId, setSendingInvoiceId] = useState<string | null>(null);
 
     useEffect(() => {
         (async () => {
             setLoading(true);
-            setError(null);
+            setLoadError(null);
 
             try {
                 const response = await fetch('/api/billing');
@@ -29,12 +39,49 @@ export default function AdminBillingsPage() {
                 setBillings(data);
             } catch (fetchError) {
                 console.error(fetchError);
-                setError(fetchError instanceof Error ? fetchError.message : 'Abrechnungszeiträume konnten nicht geladen werden.');
+                setLoadError(fetchError instanceof Error ? fetchError.message : 'Abrechnungszeiträume konnten nicht geladen werden.');
             } finally {
                 setLoading(false);
             }
         })();
     }, []);
+
+    async function sendInvoice(period: BillingPeriod) {
+        if (!period._id) {
+            setInvoiceError('Die Rechnung kann für diesen Abrechnungszeitraum nicht erneut versendet werden.');
+            return;
+        }
+
+        setSendingInvoiceId(period._id);
+        setInvoiceMessage(null);
+        setInvoiceError(null);
+
+        try {
+            const response = await fetch('/api/billing', {
+                method: 'POST',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    action: 'send_invoice',
+                    billing_period_id: period._id,
+                })
+            });
+            const data = await response.json();
+
+            if (!response.ok || data.error) {
+                throw new Error(data.error ?? 'Die Rechnung konnte nicht versendet werden.');
+            }
+
+            setInvoiceMessage(`Die Rechnung für den Zeitraum ab ${parseLocalDate(period.period_start).toLocaleDateString('de-DE')} wurde erneut versendet.`);
+        } catch (sendError) {
+            console.error(sendError);
+            setInvoiceError(sendError instanceof Error ? sendError.message : 'Die Rechnung konnte nicht versendet werden.');
+        } finally {
+            setSendingInvoiceId(null);
+        }
+    }
 
     return (
         loading ? (
@@ -45,18 +92,22 @@ export default function AdminBillingsPage() {
             <>
                 <p><Link className="icon icon--back" to="/admin">Zurück</Link></p>
                 <h1>Abrechnungen</h1>
-                {error ? <p>{error}</p> : null}
-                {!error && !billings.length ? (
+                {loadError ? <p>{loadError}</p> : null}
+                {invoiceError ? <p>{invoiceError}</p> : null}
+                {invoiceMessage ? <p>{invoiceMessage}</p> : null}
+                {!loadError && !billings.length ? (
                     <p>Keine Abrechnungszeiträume vorhanden.</p>
                 ) : null}
-                {!error && billings.length ? (
+                {!loadError && billings.length ? (
                     <table className="profile-table billings-table">
                         <thead>
                             <tr>
                                 <th>Plan</th>
+                                <th>Preis</th>
                                 <th className="billings-table__period">Zeitraum</th>
                                 <th>Status</th>
                                 <th className="billings-table__date">Erstellt am</th>
+                                <th>Aktion</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -66,6 +117,7 @@ export default function AdminBillingsPage() {
                                 return (
                                     <tr key={period._id ?? `${period.period_start}-${period.period_end}`}>
                                         <td>{getPlanName(period.plan_type)}</td>
+                                        <td>{formatCurrency(period.price)}</td>
                                         <td className="billings-table__period">
                                             {parseLocalDate(period.period_start).toLocaleDateString('de-DE')}
                                             {' - '}
@@ -73,6 +125,16 @@ export default function AdminBillingsPage() {
                                         </td>
                                         <td>{period.status}</td>
                                         <td className="billings-table__date">{new Date(period.created_at).toLocaleDateString('de-DE')}</td>
+                                        <td>
+                                            <button
+                                                type="button"
+                                                className="button-link button-link--secondary"
+                                                disabled={!period._id || sendingInvoiceId === period._id}
+                                                onClick={() => sendInvoice(period)}
+                                            >
+                                                {sendingInvoiceId === period._id ? 'Wird gesendet...' : 'Rechnung senden'}
+                                            </button>
+                                        </td>
                                     </tr>
                                 );
                             })}

--- a/src/planConfig.ts
+++ b/src/planConfig.ts
@@ -96,6 +96,10 @@ export function getMembersLimitForPlan(planType?: PlanType) {
     return getPlanConfig(planType).membersLimit;
 }
 
+export function getPlanPrice(planType?: PlanType) {
+    return getPlanConfig(planType).price;
+}
+
 export function getNextBillingPeriodStartForPlan(planType?: PlanType, fromDate = new Date(), anchorDay = fromDate.getDate()) {
     const config = getPlanConfig(planType);
     const nextPeriodStart = addMonthsKeepingDay(fromDate, config.durationMonths, anchorDay);

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export type BillingPeriod = {
     _id?: string;
     club_id: string;
     plan_type: PlanType;
+    price: number;
     anchor_day: number;
     period_start: string;
     period_end: string;


### PR DESCRIPTION
## What changed

This PR adds invoice-style billing emails and admin resend support for billing periods.

It also tightens the billing data model so each billing period stores a required price snapshot that is used as the invoice source of truth, and it adds a backfill script for older billing records.

To keep the billing endpoint easier to maintain, the invoice rendering and delivery logic was extracted into a dedicated billing invoice helper.

## Why

We wanted billing periods to serve as the source of truth for invoicing, allow admins to resend invoices for an existing period, and make invoice delivery failures visible instead of silently reporting success.

## User impact

- Admins can resend the invoice email for a billing period from the admin billing list.
- Invoice emails now look like invoices and include VAT, club address details, payment instructions, and a stable invoice reference.
- If invoice delivery fails, the API now responds with a clear message that explains whether the billing period already exists or was created successfully before the email failed.

## Validation

- `npm run build`
