### PR TITLE
Issue invoice emails for lazy billing repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project should be documented in this file.
 - Changed the admin billing list to show billing-period prices and clearer invoice resend status messages.
 - Changed invoice delivery handling so API responses clearly distinguish between a created billing period and a failed invoice email delivery.
 - Changed `api/billing.ts` to delegate invoice rendering and delivery work to a dedicated billing-invoice helper, keeping the endpoint logic smaller and easier to maintain.
+- Changed the admin billing list endpoint to recreate a missing initial billing period as a lazy fallback when a club has no billing periods at all, and to issue the invoice email for that repair-created period immediately.
 
 ## 0.0.17
 

--- a/api/_utils/_billingInvoices.ts
+++ b/api/_utils/_billingInvoices.ts
@@ -6,7 +6,7 @@ import sendEmail from './_sendEmail.js';
 import { BillingPeriodDocument } from './_billingPeriods.js';
 import { AdminEmailDocument, ClubDocument } from './_types.js';
 
-export type BillingInvoiceNotificationType = 'manual' | 'renewal' | 'resend';
+export type BillingInvoiceNotificationType = 'manual' | 'renewal' | 'resend' | 'repair';
 
 function parseLocalDate(dateString: string) {
   return new Date(`${dateString}T12:00:00`);
@@ -78,6 +78,8 @@ function buildBillingPeriodNotificationEmail(
   const hasBankDetails = Boolean(bank_iban && bank_name && bank_account_holder);
   const note = notificationType === 'renewal'
     ? 'Dieser Abrechnungszeitraum wurde automatisch bei der Verlängerung Ihres Plans angelegt.'
+    : notificationType === 'repair'
+      ? 'Dieser Abrechnungszeitraum wurde als Reparatur für fehlende Abrechnungsdaten angelegt.'
     : notificationType === 'resend'
       ? 'Diese Rechnung wurde auf Anfrage erneut versendet.'
       : 'Dieser Abrechnungszeitraum wurde manuell angelegt.';

--- a/api/billing.ts
+++ b/api/billing.ts
@@ -5,7 +5,7 @@ import { getJwtPayload } from './verifyAuth.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { DBUser, PlanType } from '../src/types.js';
 import { ClubDocument } from './_utils/_types.js';
-import { BillingPeriodDocument, BillingPeriodStatus, processBillingRenewals, processClubBillingRenewal } from './_utils/_billingPeriods.js';
+import { BillingPeriodDocument, BillingPeriodStatus, createInitialBillingPeriod, processBillingRenewals, processClubBillingRenewal } from './_utils/_billingPeriods.js';
 import { getPlanStateAtRenewal } from './_utils/_planTransitions.js';
 import { getPlanPrice } from '../src/planConfig.js';
 import { getRequiredBillingPrice, sendBillingPeriodInvoiceEmail } from './_utils/_billingInvoices.js';
@@ -163,6 +163,42 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         period_start: -1,
         created_at: -1
       }).toArray();
+
+      if (!periods.length) {
+        const club = await clubs.findOne({
+          _id: ObjectId.createFromHexString(requestedClubId)
+        });
+        if (!club) {
+          return res.status(404).json({error: 'Club not found'});
+        }
+
+        const createdPeriod = await createInitialBillingPeriod(
+          billingPeriods,
+          requestedClubId,
+          club.next_plan_type ?? club.access_plan_type,
+          'lazy_repair'
+        );
+
+        try {
+          await sendBillingPeriodInvoiceEmail(
+            database,
+            club,
+            createdPeriod,
+            'repair'
+          );
+        } catch (emailError) {
+          console.error('Failed to send invoice email for lazily repaired billing period', emailError);
+          const detail = emailError instanceof Error
+            ? ` ${emailError.message}`
+            : '';
+          return res.status(502).json({
+            error: `Der fehlende Abrechnungszeitraum wurde angelegt, aber die Rechnungs-E-Mail konnte nicht zugestellt werden.${detail}`,
+            data: normalizeBillingPeriod(createdPeriod),
+          });
+        }
+
+        periods.push(createdPeriod);
+      }
 
       return res.json(periods.map(normalizeBillingPeriod));
     }


### PR DESCRIPTION
## What changed

This PR adds a narrow lazy-repair fallback for clubs that have no billing periods at all when the admin billing page is opened.

When that repair path creates a missing billing period, it now immediately attempts invoice issuance as well, so the system keeps the invariant that every created billing period should issue an invoice.

It also adds a dedicated `repair` invoice notification type so the invoice note accurately describes why the period was created.

## Why

PR #108 introduced invoice issuance for billing period creation and resend flows, but the later lazy-repair fallback for missing billing periods would have created a period without issuing an invoice. This follow-up keeps the billing-period and invoice behavior consistent.

## User impact

- If a club has no billing periods and an admin opens the billing page, the missing initial billing period is recreated automatically.
- That repair-created billing period now also triggers invoice email delivery immediately.
- If the repair succeeds but invoice delivery fails, the API returns a clear error explaining that the billing period was created but the invoice email could not be delivered.

## Validation

- `npm run build`
