### PR TITLE
Centralize billing invoice delivery and numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project should be documented in this file.
 
+## 0.0.20
+
+### Added
+
+- Added a reusable invoice-number backfill script for billing periods without a persisted `invoice_number`.
+- Added a dedicated TypeScript configuration for API code and included it in the production build.
+
+### Changed
+
+- Removed club IDs from new-member and new-club registration emails when the club name already identifies the club.
+- Changed role and status values in registration emails to use German labels such as `Spieler`, `Administrator`, `Aktiv`, and `Inaktiv`.
+- Changed registration timestamps in admin emails to the format `DD.MM.YYYY um HH:MM Uhr` using the `Europe/Berlin` timezone.
+- Changed billing periods to require persisted, application-wide yearly invoice numbers such as `AZP20260001`, without club-ID fragments, separators, or legacy reference generation.
+- Changed billing-period creation to always attempt invoice delivery through one centralized service, including registration, scheduled and fallback renewal, manual creation, and repair.
+- Expanded `PLANS.md` with invoice-email triggers, recipients, delivery behavior, contents, resend behavior, and invoice-number rules.
+
 ## 0.0.19
 
 ### Added

--- a/PLANS.md
+++ b/PLANS.md
@@ -47,6 +47,7 @@ The `billing_periods` collection is the source of truth for plan-period history.
 Each billing period stores:
 
 - `club_id`
+- `invoice_number`
 - `plan_type`
 - `price`
 - `period_start`
@@ -181,6 +182,46 @@ Invoices are based on whole billing periods.
 - the invoice for the current period is based on that billing period document
 - each billing period stores the plan price snapshot that applied when that period was created
 - the next invoice uses the plan that becomes effective at renewal
+
+### Invoice Email Delivery
+
+Invoice emails are sent to every active administrator assigned to the club.
+
+An invoice email is sent:
+
+- immediately after the initial billing period is created during club registration
+- automatically for every billing period created by the scheduled renewal process
+- automatically for every billing period created by fallback renewal in another write workflow
+- immediately after an administrator manually creates a billing period
+- immediately after `GET /api/billing` repairs a club that has no billing periods by creating a missing initial period
+- when an administrator uses the resend action for an existing billing period
+
+If renewal processing catches up multiple missed periods, one invoice email is sent for each newly created period.
+
+Invoice emails include:
+
+- the club name and address
+- the invoiced plan and billing period
+- the stored price snapshot, including net amount and VAT
+- a stable invoice reference
+- bank-transfer instructions when the required bank details are configured
+
+New billing periods receive a persisted invoice number in the format `AZPYYYYNNNN`, for example `AZP20260001`.
+
+- `YYYY` is the invoice year in the `Europe/Berlin` timezone
+- `NNNN` is an application-wide sequence that starts at `0001` each year
+- the sequence is allocated atomically from the `invoice_counters` collection
+- the number contains no club ID and is not changed when an invoice is resent
+- invoice delivery fails clearly if a billing period does not have a persisted `invoice_number`
+
+Delivery behavior:
+
+- billing-period creation and its initial invoice-delivery attempt are coordinated by one billing service
+- invoice delivery uses the email transport configured by the application
+- a manually created or repair-created billing period remains stored if email delivery fails
+- the API reports the delivery failure separately from the successful billing-period creation
+- renewal processing reports failed invoice deliveries after completing the billing-period renewals
+- resending an invoice does not create a new billing period or change the existing one
 
 ## Member Limits
 

--- a/api/_utils/_billingInvoices.ts
+++ b/api/_utils/_billingInvoices.ts
@@ -6,7 +6,7 @@ import sendEmail from './_sendEmail.js';
 import { BillingPeriodDocument } from './_billingPeriods.js';
 import { AdminEmailDocument, ClubDocument } from './_types.js';
 
-export type BillingInvoiceNotificationType = 'manual' | 'renewal' | 'resend' | 'repair';
+export type BillingInvoiceNotificationType = 'initial' | 'manual' | 'renewal' | 'resend' | 'repair';
 
 function parseLocalDate(dateString: string) {
   return new Date(`${dateString}T12:00:00`);
@@ -50,22 +50,22 @@ function buildClubAddressLines(club: Pick<ClubDocument, 'address_line1' | 'posta
   ].filter((line): line is string => Boolean(line));
 }
 
-export function getBillingInvoiceReference(clubId: string, period: BillingPeriodDocument) {
-  const periodKey = period.period_start.replaceAll('-', '');
-  const clubKey = clubId.slice(-6).toUpperCase();
-  const idKey = period._id?.toString().slice(-6).toUpperCase();
+export function getRequiredInvoiceNumber(period: BillingPeriodDocument) {
+  if (!period.invoice_number) {
+    const periodId = period._id?.toString() ?? 'unknown';
+    throw new Error(`Billing period ${periodId} is missing an invoice number.`);
+  }
 
-  return ['AZP', clubKey, periodKey, idKey].filter(Boolean).join('-');
+  return period.invoice_number;
 }
 
 function buildBillingPeriodNotificationEmail(
-  club: Pick<ClubDocument, '_id' | 'name' | 'address_line1' | 'postal_code' | 'city' | 'country'>,
+  club: Pick<ClubDocument, 'name' | 'address_line1' | 'postal_code' | 'city' | 'country'>,
   period: BillingPeriodDocument,
   notificationType: BillingInvoiceNotificationType
 ) {
-  const clubId = club._id?.toString() ?? period.club_id;
   const price = getRequiredBillingPrice(period);
-  const invoiceReference = getBillingInvoiceReference(clubId, period);
+  const invoiceReference = getRequiredInvoiceNumber(period);
   const coveredUntil = getCoveredUntilFromPeriodEnd(period.period_end) ?? period.period_end;
   const issueDate = formatDate(period.created_at);
   const serviceStart = formatDate(period.period_start);
@@ -82,6 +82,8 @@ function buildBillingPeriodNotificationEmail(
       ? 'Dieser Abrechnungszeitraum wurde als Reparatur für fehlende Abrechnungsdaten angelegt.'
     : notificationType === 'resend'
       ? 'Diese Rechnung wurde auf Anfrage erneut versendet.'
+      : notificationType === 'initial'
+        ? 'Dieser Abrechnungszeitraum wurde bei der Registrierung Ihres Vereins angelegt.'
       : 'Dieser Abrechnungszeitraum wurde manuell angelegt.';
 
   return `

--- a/api/_utils/_billingPeriods.ts
+++ b/api/_utils/_billingPeriods.ts
@@ -11,6 +11,7 @@ export type BillingPeriodStatus = 'active' | 'completed' | 'canceled';
 
 export type BillingPeriodDocument = {
     _id?: ObjectId;
+    invoice_number: string;
     club_id: string;
     plan_type: PlanType;
     price: number;
@@ -20,6 +21,13 @@ export type BillingPeriodDocument = {
     status: BillingPeriodStatus;
     created_at: Date;
     source?: string;
+}
+
+export type NewBillingPeriodDocument = Omit<BillingPeriodDocument, '_id' | 'invoice_number'>;
+
+export type InvoiceCounterDocument = {
+    _id: string;
+    sequence: number;
 }
 
 type ResolvedClubBillingState = {
@@ -68,7 +76,7 @@ function createBillingPeriodRecord(
     status: BillingPeriodStatus,
     source?: string,
     anchorDay = startDate.getDate()
-): BillingPeriodDocument {
+): NewBillingPeriodDocument {
     return {
         club_id: clubId,
         plan_type: planType,
@@ -82,13 +90,49 @@ function createBillingPeriodRecord(
     };
 }
 
-async function insertBillingPeriod(
-    collection: Collection<BillingPeriodDocument>,
-    period: BillingPeriodDocument
+function getInvoiceYear(value: Date) {
+    return new Intl.DateTimeFormat('en', {
+        year: 'numeric',
+        timeZone: 'Europe/Berlin',
+    }).format(value);
+}
+
+async function getNextInvoiceNumber(
+    invoiceCountersCollection: Collection<InvoiceCounterDocument>,
+    issueDate: Date
 ) {
-    const result = await collection.insertOne(period);
-    period._id = result.insertedId;
-    return period;
+    const year = getInvoiceYear(issueDate);
+    const counter = await invoiceCountersCollection.findOneAndUpdate(
+        {_id: `invoice:${year}`},
+        {$inc: {sequence: 1}},
+        {
+            upsert: true,
+            returnDocument: 'after',
+        }
+    );
+
+    if (!counter) {
+        throw new Error(`Could not allocate an invoice number for ${year}.`);
+    }
+
+    return `AZP${year}${counter.sequence.toString().padStart(4, '0')}`;
+}
+
+export async function insertBillingPeriod(
+    collection: Collection<BillingPeriodDocument>,
+    invoiceCountersCollection: Collection<InvoiceCounterDocument>,
+    period: NewBillingPeriodDocument
+) {
+    const document: BillingPeriodDocument = {
+        ...period,
+        invoice_number: await getNextInvoiceNumber(
+            invoiceCountersCollection,
+            period.created_at
+        ),
+    };
+    const result = await collection.insertOne(document);
+    document._id = result.insertedId;
+    return document;
 }
 
 async function getLatestBillingPeriod(
@@ -164,6 +208,7 @@ export function isDowngradeLocked(
 
 export async function createInitialBillingPeriod(
     collection: Collection<BillingPeriodDocument>,
+    invoiceCountersCollection: Collection<InvoiceCounterDocument>,
     clubId: string,
     planType: PlanType,
     source?: string,
@@ -172,6 +217,7 @@ export async function createInitialBillingPeriod(
 ) {
     return insertBillingPeriod(
         collection,
+        invoiceCountersCollection,
         createBillingPeriodRecord(clubId, planType, startDate, 'active', source, anchorDay)
     );
 }
@@ -203,6 +249,7 @@ export async function getClubBillingState(
 export async function processClubBillingRenewal(
     clubsCollection: Collection<ClubDocument>,
     billingPeriodsCollection: Collection<BillingPeriodDocument>,
+    invoiceCountersCollection: Collection<InvoiceCounterDocument>,
     club: ClubDocument,
     now = new Date()
 ): Promise<ProcessedClubBillingRenewal> {
@@ -285,7 +332,11 @@ export async function processClubBillingRenewal(
         if (hasFutureBillingPeriodEnd(nextPeriod.period_end, now)) {
             renewalApplied = true;
             createdPeriodsCount += 1;
-            const insertedPeriod = await insertBillingPeriod(billingPeriodsCollection, nextPeriod);
+            const insertedPeriod = await insertBillingPeriod(
+                billingPeriodsCollection,
+                invoiceCountersCollection,
+                nextPeriod
+            );
             createdPeriods.push(insertedPeriod);
             return {
                 club: resolvedClub,
@@ -300,10 +351,14 @@ export async function processClubBillingRenewal(
         renewalApplied = true;
         completedPeriodsCount += 1;
         createdPeriodsCount += 1;
-        const insertedCompletedPeriod = await insertBillingPeriod(billingPeriodsCollection, {
-            ...nextPeriod,
-            status: 'completed'
-        });
+        const insertedCompletedPeriod = await insertBillingPeriod(
+            billingPeriodsCollection,
+            invoiceCountersCollection,
+            {
+                ...nextPeriod,
+                status: 'completed'
+            }
+        );
         createdPeriods.push(insertedCompletedPeriod);
         nextStartDate = new Date(`${nextPeriod.period_end}T12:00:00`);
     }
@@ -312,6 +367,7 @@ export async function processClubBillingRenewal(
 export async function processBillingRenewals(
     clubsCollection: Collection<ClubDocument>,
     billingPeriodsCollection: Collection<BillingPeriodDocument>,
+    invoiceCountersCollection: Collection<InvoiceCounterDocument>,
     now = new Date()
 ): Promise<ProcessedBillingRenewalsResult> {
     const clubs = await clubsCollection.find({}).toArray();
@@ -327,6 +383,7 @@ export async function processBillingRenewals(
         const result = await processClubBillingRenewal(
             clubsCollection,
             billingPeriodsCollection,
+            invoiceCountersCollection,
             club,
             now
         );

--- a/api/_utils/_billingService.ts
+++ b/api/_utils/_billingService.ts
@@ -1,0 +1,147 @@
+import { Collection, Db } from 'mongodb';
+import { PlanType } from '../../src/types.js';
+import {
+  BillingPeriodDocument,
+  createInitialBillingPeriod,
+  insertBillingPeriod,
+  InvoiceCounterDocument,
+  NewBillingPeriodDocument,
+  processBillingRenewals,
+  ProcessedBillingRenewalsResult,
+  processClubBillingRenewal,
+} from './_billingPeriods.js';
+import {
+  BillingInvoiceNotificationType,
+  sendBillingPeriodInvoiceEmail,
+} from './_billingInvoices.js';
+import { ClubDocument } from './_types.js';
+
+export class BillingPeriodInvoiceDeliveryError extends Error {
+  period: BillingPeriodDocument;
+
+  constructor(period: BillingPeriodDocument, cause: unknown) {
+    super(`Billing period ${period._id?.toString() ?? 'unknown'} was created, but its invoice email could not be delivered.`, {
+      cause,
+    });
+    this.name = 'BillingPeriodInvoiceDeliveryError';
+    this.period = period;
+  }
+}
+
+async function sendCreatedPeriodInvoices(
+  database: Db,
+  club: ClubDocument,
+  periods: BillingPeriodDocument[],
+  notificationType: BillingInvoiceNotificationType
+) {
+  const results = await Promise.allSettled(periods.map(period =>
+    sendBillingPeriodInvoiceEmail(database, club, period, notificationType)
+  ));
+  const failures = results.filter((result): result is PromiseRejectedResult =>
+    result.status === 'rejected'
+  );
+
+  if (failures.length) {
+    throw new AggregateError(
+      failures.map(result => result.reason),
+      `Invoice email delivery failed for ${failures.length} billing period(s).`
+    );
+  }
+}
+
+export async function createInitialBillingPeriodAndSendInvoice(
+  database: Db,
+  billingPeriodsCollection: Collection<BillingPeriodDocument>,
+  invoiceCountersCollection: Collection<InvoiceCounterDocument>,
+  club: ClubDocument,
+  clubId: string,
+  planType: PlanType,
+  source?: string,
+  startDate = new Date(),
+  anchorDay = startDate.getDate(),
+  notificationType: Extract<BillingInvoiceNotificationType, 'initial' | 'repair'> = 'initial'
+) {
+  const period = await createInitialBillingPeriod(
+    billingPeriodsCollection,
+    invoiceCountersCollection,
+    clubId,
+    planType,
+    source,
+    startDate,
+    anchorDay
+  );
+  try {
+    await sendBillingPeriodInvoiceEmail(database, club, period, notificationType);
+  } catch (error) {
+    throw new BillingPeriodInvoiceDeliveryError(period, error);
+  }
+  return period;
+}
+
+export async function createManualBillingPeriodAndSendInvoice(
+  database: Db,
+  billingPeriodsCollection: Collection<BillingPeriodDocument>,
+  invoiceCountersCollection: Collection<InvoiceCounterDocument>,
+  club: ClubDocument,
+  period: NewBillingPeriodDocument
+) {
+  const insertedPeriod = await insertBillingPeriod(
+    billingPeriodsCollection,
+    invoiceCountersCollection,
+    period
+  );
+  try {
+    await sendBillingPeriodInvoiceEmail(database, club, insertedPeriod, 'manual');
+  } catch (error) {
+    throw new BillingPeriodInvoiceDeliveryError(insertedPeriod, error);
+  }
+  return insertedPeriod;
+}
+
+export async function processClubBillingRenewalAndSendInvoices(
+  database: Db,
+  clubsCollection: Collection<ClubDocument>,
+  billingPeriodsCollection: Collection<BillingPeriodDocument>,
+  invoiceCountersCollection: Collection<InvoiceCounterDocument>,
+  club: ClubDocument,
+  now = new Date()
+) {
+  const result = await processClubBillingRenewal(
+    clubsCollection,
+    billingPeriodsCollection,
+    invoiceCountersCollection,
+    club,
+    now
+  );
+  await sendCreatedPeriodInvoices(database, result.club, result.createdPeriods, 'renewal');
+  return result;
+}
+
+export async function processBillingRenewalsAndSendInvoices(
+  database: Db,
+  clubsCollection: Collection<ClubDocument>,
+  billingPeriodsCollection: Collection<BillingPeriodDocument>,
+  invoiceCountersCollection: Collection<InvoiceCounterDocument>,
+  now = new Date()
+): Promise<ProcessedBillingRenewalsResult & { failedInvoiceDeliveries: PromiseRejectedResult[] }> {
+  const result = await processBillingRenewals(
+    clubsCollection,
+    billingPeriodsCollection,
+    invoiceCountersCollection,
+    now
+  );
+  const deliveries = await Promise.allSettled(
+    result.renewedClubs.flatMap(({club, createdPeriods}) =>
+      createdPeriods.map(period =>
+        sendBillingPeriodInvoiceEmail(database, club, period, 'renewal')
+      )
+    )
+  );
+
+  return {
+    ...result,
+    failedInvoiceDeliveries: deliveries.filter(
+      (delivery): delivery is PromiseRejectedResult => delivery.status === 'rejected'
+    ),
+  };
+}

--- a/api/_utils/_editReservation.ts
+++ b/api/_utils/_editReservation.ts
@@ -39,6 +39,7 @@ type ValidatedEditRequest = {
     start_time: number;
     end_time: number;
     recurring: boolean;
+    user_id?: string;
   };
 };
 
@@ -79,7 +80,7 @@ const validateEditRequest = (
   body: Record<string, unknown>,
   userRole: string,
   club: ReservationClub
-): ValidatedEditRequest | { error: unknown } | { status: 403; body: { error: string } } => {
+): ValidatedEditRequest | { error: unknown } | ReturnType<typeof getAppErrorResponse> => {
   const {
     reservation_id: _reservationId,
     assign_to_myself: assignToMyselfValue,

--- a/api/billing.ts
+++ b/api/billing.ts
@@ -5,10 +5,17 @@ import { getJwtPayload } from './verifyAuth.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { DBUser, PlanType } from '../src/types.js';
 import { ClubDocument } from './_utils/_types.js';
-import { BillingPeriodDocument, BillingPeriodStatus, createInitialBillingPeriod, processBillingRenewals, processClubBillingRenewal } from './_utils/_billingPeriods.js';
+import { BillingPeriodDocument, BillingPeriodStatus, InvoiceCounterDocument, NewBillingPeriodDocument } from './_utils/_billingPeriods.js';
 import { getPlanStateAtRenewal } from './_utils/_planTransitions.js';
 import { getPlanPrice } from '../src/planConfig.js';
 import { getRequiredBillingPrice, sendBillingPeriodInvoiceEmail } from './_utils/_billingInvoices.js';
+import {
+  BillingPeriodInvoiceDeliveryError,
+  createInitialBillingPeriodAndSendInvoice,
+  createManualBillingPeriodAndSendInvoice,
+  processBillingRenewalsAndSendInvoices,
+  processClubBillingRenewalAndSendInvoices,
+} from './_utils/_billingService.js';
 
 type BillingBody = {
   action?: 'create_period' | 'send_invoice';
@@ -91,23 +98,15 @@ export default async (req: VercelRequest, res: VercelResponse) => {
     const users = database.collection<DBUser>('users');
     const clubs = database.collection<ClubDocument>('clubs');
     const billingPeriods = database.collection<BillingPeriodDocument>('billing_periods');
+    const invoiceCounters = database.collection<InvoiceCounterDocument>('invoice_counters');
 
     if (isAuthorizedRenewalRequest(req)) {
-      const { summary, renewedClubs } = await processBillingRenewals(clubs, billingPeriods);
-      const invoiceDeliveries = await Promise.allSettled(renewedClubs.flatMap(({club, createdPeriods}) => createdPeriods.map(async (period) => {
-        if (!club._id) {
-          return;
-        }
-
-        await sendBillingPeriodInvoiceEmail(
-          database,
-          club,
-          period,
-          'renewal'
-        );
-      })));
-
-      const failedInvoiceDeliveries = invoiceDeliveries.filter((result) => result.status === 'rejected');
+      const { summary, failedInvoiceDeliveries } = await processBillingRenewalsAndSendInvoices(
+        database,
+        clubs,
+        billingPeriods,
+        invoiceCounters
+      );
       if (failedInvoiceDeliveries.length) {
         failedInvoiceDeliveries.forEach((result) => {
           if (result.status === 'rejected') {
@@ -157,7 +156,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         return res.status(403).json({error: 'Reading billing periods for another club is not allowed'});
       }
 
-      const periods = await billingPeriods.find({
+      const periods: BillingPeriodDocument[] = await billingPeriods.find({
         club_id: requestedClubId
       }).sort({
         period_start: -1,
@@ -172,20 +171,20 @@ export default async (req: VercelRequest, res: VercelResponse) => {
           return res.status(404).json({error: 'Club not found'});
         }
 
-        const createdPeriod = await createInitialBillingPeriod(
-          billingPeriods,
-          requestedClubId,
-          club.next_plan_type ?? club.access_plan_type,
-          'lazy_repair'
-        );
-
         try {
-          await sendBillingPeriodInvoiceEmail(
+          const createdPeriod = await createInitialBillingPeriodAndSendInvoice(
             database,
+            billingPeriods,
+            invoiceCounters,
             club,
-            createdPeriod,
+            requestedClubId,
+            club.next_plan_type ?? club.access_plan_type,
+            'lazy_repair',
+            new Date(),
+            new Date().getDate(),
             'repair'
           );
+          periods.push(createdPeriod);
         } catch (emailError) {
           console.error('Failed to send invoice email for lazily repaired billing period', emailError);
           const detail = emailError instanceof Error
@@ -193,11 +192,11 @@ export default async (req: VercelRequest, res: VercelResponse) => {
             : '';
           return res.status(502).json({
             error: `Der fehlende Abrechnungszeitraum wurde angelegt, aber die Rechnungs-E-Mail konnte nicht zugestellt werden.${detail}`,
-            data: normalizeBillingPeriod(createdPeriod),
+            ...(emailError instanceof BillingPeriodInvoiceDeliveryError
+              ? {data: normalizeBillingPeriod(emailError.period)}
+              : {}),
           });
         }
-
-        periods.push(createdPeriod);
       }
 
       return res.json(periods.map(normalizeBillingPeriod));
@@ -301,7 +300,13 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         return res.status(404).json(validationError('/club_id', 'Verein nicht gefunden.'));
       }
 
-      const { club: resolvedClub } = await processClubBillingRenewal(clubs, billingPeriods, club);
+      const { club: resolvedClub } = await processClubBillingRenewalAndSendInvoices(
+        database,
+        clubs,
+        billingPeriods,
+        invoiceCounters,
+        club
+      );
 
       const billingPlanType = plan_type ?? resolvedClub.next_plan_type;
 
@@ -315,7 +320,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         }
       }
 
-      const period: BillingPeriodDocument = {
+      const period: NewBillingPeriodDocument = {
         club_id,
         plan_type: billingPlanType,
         price: getPlanPrice(billingPlanType),
@@ -327,47 +332,54 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         ...(source ? {source} : {})
       };
 
-      const insertResult = await billingPeriods.insertOne(period);
-      period._id = insertResult.insertedId;
-
-      if (status === 'active') {
-        await clubs.updateOne(
-          {_id: ObjectId.createFromHexString(club_id)},
-          {
-            $set: getPlanStateAtRenewal(billingPlanType),
-            $unset: {
-              plan_type: '',
-            }
-          }
-        );
-      }
-
       try {
-        await sendBillingPeriodInvoiceEmail(
+        const insertedPeriod = await createManualBillingPeriodAndSendInvoice(
           database,
+          billingPeriods,
+          invoiceCounters,
           club,
-          period,
-          'manual'
+          period
         );
+
+        if (status === 'active') {
+          await clubs.updateOne(
+            {_id: ObjectId.createFromHexString(club_id)},
+            {
+              $set: getPlanStateAtRenewal(billingPlanType),
+              $unset: {
+                plan_type: '',
+              }
+            }
+          );
+        }
+
+        return res.status(201).json({
+          message: 'Billing period created.',
+          data: normalizeBillingPeriod(insertedPeriod),
+        });
       } catch (emailError) {
         console.error('Failed to send invoice email for manually created billing period', emailError);
+        if (status === 'active' && emailError instanceof BillingPeriodInvoiceDeliveryError) {
+          await clubs.updateOne(
+            {_id: ObjectId.createFromHexString(club_id)},
+            {
+              $set: getPlanStateAtRenewal(billingPlanType),
+              $unset: {
+                plan_type: '',
+              }
+            }
+          );
+        }
         const detail = emailError instanceof Error
           ? ` ${emailError.message}`
           : '';
         return res.status(502).json({
           error: `Der Abrechnungszeitraum wurde angelegt, aber die Rechnungs-E-Mail konnte nicht zugestellt werden.${detail}`,
-          data: normalizeBillingPeriod(period),
+          ...(emailError instanceof BillingPeriodInvoiceDeliveryError
+            ? {data: normalizeBillingPeriod(emailError.period)}
+            : {}),
         });
       }
-
-      return res.status(201).json({
-        message: 'Billing period created.',
-        data: {
-          ...normalizeBillingPeriod({
-            ...period,
-          })
-        }
-      });
     }
 
     return res.status(405).json({error: 'Method not allowed'});

--- a/api/clubs.ts
+++ b/api/clubs.ts
@@ -1,4 +1,4 @@
-import { Collection, MongoClient, ObjectId, WithId } from 'mongodb';
+import { Collection, Db, MongoClient, ObjectId, WithId } from 'mongodb';
 import { database_uri, database_name } from './_utils/_config.js';
 import { sanitize, ajv, getCustomErrorMessage } from './_utils/_lib.js';
 import * as fs from 'fs';
@@ -7,7 +7,8 @@ import { ClubWithBilling, DBUser, JwtPayload } from '../src/types.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { ClubDocument, ClubFormBody, CourtsFormBody } from './_utils/_types.js';
 import { updateCourts } from './_utils/_updateCourts.js';
-import { createInitialBillingPeriod, BillingPeriodDocument, getClubBillingState, isDowngradeLocked, processClubBillingRenewal } from './_utils/_billingPeriods.js';
+import { BillingPeriodDocument, getClubBillingState, InvoiceCounterDocument, isDowngradeLocked } from './_utils/_billingPeriods.js';
+import { BillingPeriodInvoiceDeliveryError, createInitialBillingPeriodAndSendInvoice, processClubBillingRenewalAndSendInvoices } from './_utils/_billingService.js';
 import { getClubPlanState, getPlanChangeUpdate } from './_utils/_planTransitions.js';
 import { fetchClub } from './_utils/_fetchClub.js';
 import { isLowerPlan } from '../src/planConfig.js';
@@ -50,6 +51,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
     const database = client.db(database_name);
     const collection = database.collection<ClubDocument>('clubs');
     const billingPeriodsCollection = database.collection<BillingPeriodDocument>('billing_periods');
+    const invoiceCountersCollection = database.collection<InvoiceCounterDocument>('invoice_counters');
     const userCollection = database.collection<DBUser>('users');
 
     if (req.method === 'GET') {
@@ -130,9 +132,9 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       }
 
       if (body._id) {
-        return await updateClub(collection, billingPeriodsCollection, res, body as ClubFormBody, requester);
+        return await updateClub(database, collection, billingPeriodsCollection, invoiceCountersCollection, res, body as ClubFormBody, requester);
       } else {
-        return await addClub(collection, billingPeriodsCollection, res, body as ClubFormBody, userCollection, payload, requester);
+        return await addClub(database, collection, billingPeriodsCollection, invoiceCountersCollection, res, body as ClubFormBody, userCollection, payload, requester);
       }
     }
 
@@ -152,8 +154,10 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 }
 
 async function addClub(
+  database: Db,
   collection: Collection<ClubDocument>,
   billingPeriodsCollection: Collection<BillingPeriodDocument>,
+  invoiceCountersCollection: Collection<InvoiceCounterDocument>,
   res: VercelResponse,
   body: ClubFormBody,
   userCollection: Collection<DBUser>,
@@ -213,8 +217,6 @@ async function addClub(
   const insertResponse = await collection.insertOne(club);
   const club_id = insertResponse.insertedId.toString();
 
-  await createInitialBillingPeriod(billingPeriodsCollection, club_id, body.plan_type, 'signup');
-
   if (club_id) {
     const query = {_id: ObjectId.createFromHexString(payload._id)};
     await userCollection.updateOne(
@@ -223,19 +225,44 @@ async function addClub(
     );
   }
 
+  let invoiceEmailError: string | undefined;
+  try {
+    await createInitialBillingPeriodAndSendInvoice(
+      database,
+      billingPeriodsCollection,
+      invoiceCountersCollection,
+      {
+        ...club,
+        _id: insertResponse.insertedId,
+      },
+      club_id,
+      body.plan_type,
+      'signup'
+    );
+  } catch (error) {
+    if (!(error instanceof BillingPeriodInvoiceDeliveryError)) {
+      throw error;
+    }
+    console.error('Failed to send invoice email for newly created club', error);
+    invoiceEmailError = error.message;
+  }
+
   const docs = await getAllClubs(collection, billingPeriodsCollection);
   res.status(201).json({
     message: `Verein ${club.name} ist registeriert mit id ${club_id}`,
     data: {
       club_id,
-      clubs: docs
+      clubs: docs,
+      ...(invoiceEmailError ? {invoice_email_error: invoiceEmailError} : {}),
     }
   });
 }
 
 async function updateClub(
+  database: Db,
   collection: Collection<ClubDocument>,
   billingPeriodsCollection: Collection<BillingPeriodDocument>,
+  invoiceCountersCollection: Collection<InvoiceCounterDocument>,
   res: VercelResponse,
   body: ClubFormBody,
   requester: WithId<DBUser>
@@ -263,9 +290,11 @@ async function updateClub(
   if (!doc) {
     return res.status(404).json({error: 'Club not found'});
   }
-  const { club: resolvedClub, currentBillingPeriod } = await processClubBillingRenewal(
+  const { club: resolvedClub, currentBillingPeriod } = await processClubBillingRenewalAndSendInvoices(
+    database,
     collection,
     billingPeriodsCollection,
+    invoiceCountersCollection,
     doc
   );
   const currentAccessPlanType = resolvedClub.access_plan_type;
@@ -293,7 +322,7 @@ async function updateClub(
 
   const query = {_id: ObjectId.createFromHexString(body._id)};
   const planUpdateFields: Partial<ClubDocument> = getPlanChangeUpdate(currentPlanState, selectedPlanType);
-  const unsetFields: Record<string, string> = {
+  const unsetFields: Record<string, ''> = {
     plan_type: '',
     members_limit: '',
     auto_renew: '',

--- a/api/nodemailer.d.ts
+++ b/api/nodemailer.d.ts
@@ -1,0 +1,1 @@
+declare module 'nodemailer';

--- a/api/reset-password.ts
+++ b/api/reset-password.ts
@@ -83,7 +83,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
                         resetTokenHash: '',
                         resetTokenExpiry: ''
                     }
-                };
+                } as const;
                 await collection.updateOne(filter, updateDoc);
                 // console.log(
                 //     `${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)`,

--- a/api/signup-club.ts
+++ b/api/signup-club.ts
@@ -16,11 +16,11 @@ if (!database_uri || !database_name) {
 const client = new MongoClient(database_uri);
 const schema = JSON.parse(fs.readFileSync(process.cwd() + '/public/schema/signup-club.json', 'utf8'));
 
-const sendNewClubNotification = async (body: SignupClubBody, clubId: string) => {
+const sendNewClubNotification = async (body: SignupClubBody) => {
     await sendEmail({
         email: 'info@abzumplatz@de',
         subject: `New club registration: ${body.name}`,
-        text: `A new club has been registered on Abzumplatz.\n\nClub: ${body.name}\nClub ID: ${clubId}\nPlan: ${body.plan_type}\nAdmin: ${body.first_name} ${body.last_name}\nAdmin email: ${body.email}\nCourts: ${body.courts_count}`,
+        text: `A new club has been registered on Abzumplatz.\n\nClub: ${body.name}\nPlan: ${body.plan_type}\nAdmin: ${body.first_name} ${body.last_name}\nAdmin email: ${body.email}\nCourts: ${body.courts_count}`,
     });
 };
 
@@ -110,7 +110,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
             );
 
             try {
-                await sendNewClubNotification(body, club_id);
+                await sendNewClubNotification(body);
             } catch (emailError) {
                 console.error('Failed to send new club registration email', emailError);
             }

--- a/api/signup-club.ts
+++ b/api/signup-club.ts
@@ -7,7 +7,8 @@ import { MongoClient, ObjectId } from 'mongodb';
 import { database_uri, database_name } from './_utils/_config.js';
 import type { VercelRequest, VercelResponse } from './_utils/_apiTypes.js';
 import { ClubDocument, SignupClubBody } from './_utils/_types.js';
-import { createInitialBillingPeriod, BillingPeriodDocument } from './_utils/_billingPeriods.js';
+import { BillingPeriodDocument, InvoiceCounterDocument } from './_utils/_billingPeriods.js';
+import { BillingPeriodInvoiceDeliveryError, createInitialBillingPeriodAndSendInvoice } from './_utils/_billingService.js';
 
 if (!database_uri || !database_name) {
     throw new Error('Database configuration is missing');
@@ -50,6 +51,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
             const database = client.db(database_name);
             const clubs = database.collection<ClubDocument>('clubs');
             const billingPeriods = database.collection<BillingPeriodDocument>('billing_periods');
+            const invoiceCounters = database.collection<InvoiceCounterDocument>('invoice_counters');
             const existingClub = await clubs.findOne({ name: body.name },{
                 collation: { locale: "en", strength: 2 }
             });
@@ -102,12 +104,32 @@ export default async (req: VercelRequest, res: VercelResponse) => {
             const clubResponse = await clubs.insertOne(club);
             const club_id = clubResponse.insertedId.toString();
 
-            await createInitialBillingPeriod(billingPeriods, club_id, body.plan_type, 'signup');
-
             await database.collection<DBUser>('users').updateOne(
                 {_id: new ObjectId(userResponse.insertedId)},
                 {'$set' : {'club_id' : club_id}}
             );
+
+            let invoiceEmailError: string | undefined;
+            try {
+                await createInitialBillingPeriodAndSendInvoice(
+                    database,
+                    billingPeriods,
+                    invoiceCounters,
+                    {
+                        ...club,
+                        _id: clubResponse.insertedId,
+                    },
+                    club_id,
+                    body.plan_type,
+                    'signup'
+                );
+            } catch (error) {
+                if (!(error instanceof BillingPeriodInvoiceDeliveryError)) {
+                    throw error;
+                }
+                console.error('Failed to send invoice email for newly registered club', error);
+                invoiceEmailError = error.message;
+            }
 
             try {
                 await sendNewClubNotification(body);
@@ -117,6 +139,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 
             res.status(201).json({
                 message: `Verein ${club.name} ist registeriert mit id ${club_id}`,
+                ...(invoiceEmailError ? {invoice_email_error: invoiceEmailError} : {}),
             });
         } catch (e) {
             console.error(e);

--- a/api/signup.ts
+++ b/api/signup.ts
@@ -26,6 +26,19 @@ const client = new MongoClient(database_uri);
 const schema = JSON.parse(fs.readFileSync(process.cwd() + '/public/schema/signup.json', 'utf8'));
 const objectIdPattern = /^[0-9a-fA-F]{24}$/;
 
+const roleLabels: Record<string, string> = {
+    admin: 'Administrator',
+    player: 'Spieler',
+};
+
+const statusLabels: Record<string, string> = {
+    active: 'Aktiv',
+    inactive: 'Inaktiv',
+};
+
+const getRoleLabel = (role?: string) => roleLabels[role ?? ''] ?? role ?? '-';
+const getStatusLabel = (status?: string) => statusLabels[status ?? 'inactive'] ?? status ?? 'Inaktiv';
+
 const getAppOrigin = (req: VercelRequest) => {
     const protocol = req.headers['x-forwarded-proto'] ?? 'https';
     const host = req.headers.host;
@@ -34,11 +47,19 @@ const getAppOrigin = (req: VercelRequest) => {
 
 function buildNewUserNotificationEmail(user: DBUser, club: ClubDocument, membersUrl: string) {
     const fullName = `${user.first_name} ${user.last_name}`;
-    const registeredAt = new Date().toLocaleString('de-DE', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
+    const registrationDate = new Date();
+    const registeredAtDate = registrationDate.toLocaleDateString('de-DE', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
         timeZone: 'Europe/Berlin',
     });
+    const registeredAtTime = registrationDate.toLocaleTimeString('de-DE', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: 'Europe/Berlin',
+    });
+    const registeredAt = `${registeredAtDate} um ${registeredAtTime} Uhr`;
 
     return `
         <p>Ein neuer Benutzer hat sich bei ${escapeHtml(club.name ?? 'Ihrem Verein')} registriert und wartet auf Freischaltung.</p>
@@ -47,10 +68,9 @@ function buildNewUserNotificationEmail(user: DBUser, club: ClubDocument, members
                 <tbody>
                     <tr><td style="padding: 6px 6px 6px 0;"><strong>Name</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(fullName)}</td></tr>
                     <tr><td style="padding: 6px 6px 6px 0;"><strong>E-Mail</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(user.email)}</td></tr>
-                    <tr><td style="padding: 6px 6px 6px 0;"><strong>Rolle</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(user.role)}</td></tr>
-                    <tr><td style="padding: 6px 6px 6px 0;"><strong>Status</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(user.status ?? 'inactive')}</td></tr>
+                    <tr><td style="padding: 6px 6px 6px 0;"><strong>Rolle</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(getRoleLabel(user.role))}</td></tr>
+                    <tr><td style="padding: 6px 6px 6px 0;"><strong>Status</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(getStatusLabel(user.status))}</td></tr>
                     <tr><td style="padding: 6px 6px 6px 0;"><strong>Verein</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(club.name)}</td></tr>
-                    <tr><td style="padding: 6px 6px 6px 0;"><strong>Vereins-ID</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(user.club_id ?? '-')}</td></tr>
                     <tr><td style="padding: 6px 6px 6px 0;"><strong>Registriert am</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(registeredAt)}</td></tr>
                 </tbody>
             </table>
@@ -73,7 +93,7 @@ function buildWelcomeEmail(user: DBUser, club?: ClubDocument) {
                     <tr><td style="padding: 6px 6px 6px 0;"><strong>Name</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(`${user.first_name} ${user.last_name}`)}</td></tr>
                     <tr><td style="padding: 6px 6px 6px 0;"><strong>E-Mail</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(user.email)}</td></tr>
                     <tr><td style="padding: 6px 6px 6px 0;"><strong>Verein</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(hasClub ? club?.name : '-')}</td></tr>
-                    <tr><td style="padding: 6px 6px 6px 0;"><strong>Status</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(user.status ?? 'inactive')}</td></tr>
+                    <tr><td style="padding: 6px 6px 6px 0;"><strong>Status</strong></td><td style="padding: 6px 6px 6px 0;">${escapeHtml(getStatusLabel(user.status))}</td></tr>
                 </tbody>
             </table>
         </div>

--- a/api/users.ts
+++ b/api/users.ts
@@ -8,7 +8,8 @@ import { escapeHtml } from './_utils/_lib.js';
 import { ReservationItem } from '../src/types.js';
 import { ClubDocument } from './_utils/_types.js';
 import { isReservationActive } from '../src/utils/utils.js';
-import { BillingPeriodDocument, processClubBillingRenewal } from './_utils/_billingPeriods.js';
+import { BillingPeriodDocument, InvoiceCounterDocument } from './_utils/_billingPeriods.js';
+import { processClubBillingRenewalAndSendInvoices } from './_utils/_billingService.js';
 import { getEffectiveMembersLimitForPlan } from './_utils/_planLimits.js';
 
 function isString(value: unknown): value is string {
@@ -115,6 +116,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
     const collection = database.collection('users');
     const clubCollection = database.collection<ClubDocument>('clubs');
     const billingPeriodsCollection = database.collection<BillingPeriodDocument>('billing_periods');
+    const invoiceCountersCollection = database.collection<InvoiceCounterDocument>('invoice_counters');
 
     if (req.method === 'GET') {
       const payload = await getJwtPayload(req);
@@ -193,7 +195,13 @@ export default async (req: VercelRequest, res: VercelResponse) => {
         _id: ObjectId.createFromHexString(requester.club_id)
       }) : null;
       const billingState = requester.club_id && club
-        ? await processClubBillingRenewal(clubCollection, billingPeriodsCollection, club)
+        ? await processClubBillingRenewalAndSendInvoices(
+            database,
+            clubCollection,
+            billingPeriodsCollection,
+            invoiceCountersCollection,
+            club
+          )
         : null;
       const resolvedClub = billingState?.club ?? club;
       const currentBillingPeriod = billingState?.currentBillingPeriod ?? null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abzumplatz",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abzumplatz",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
         "@reduxjs/toolkit": "^2.7.0",
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "abzumplatz",
   "private": true,
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && tsc -p tsconfig.api.json && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "export:db": "node scripts/export-mongodb.js",
     "backfill:billing-prices": "node scripts/backfill-billing-period-prices.js",
+    "backfill:invoice-numbers": "node scripts/backfill-billing-period-invoice-numbers.js",
     "release:github": "node scripts/release-github.js"
   },
   "dependencies": {

--- a/scripts/backfill-billing-period-invoice-numbers.js
+++ b/scripts/backfill-billing-period-invoice-numbers.js
@@ -1,0 +1,141 @@
+import process from 'node:process';
+import dotenv from 'dotenv';
+import { MongoClient } from 'mongodb';
+
+dotenv.config({ quiet: true });
+const DEFAULT_DATABASE_NAME = 'abzumplatz';
+const INVOICE_NUMBER_PATTERN = /^AZP(\d{4})(\d+)$/;
+const MISSING_INVOICE_NUMBER = {
+  $or: [
+    { invoice_number: { $exists: false } },
+    { invoice_number: null },
+    { invoice_number: '' },
+  ],
+};
+
+function getInvoiceYear(value) {
+  return new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    timeZone: 'Europe/Berlin',
+  }).format(value);
+}
+
+function getBillingPeriodIssueDate(period) {
+  if (period.created_at instanceof Date && !Number.isNaN(period.created_at.getTime())) {
+    return period.created_at;
+  }
+
+  if (period._id?.getTimestamp) {
+    return period._id.getTimestamp();
+  }
+
+  throw new Error(`Billing period ${period._id?.toString() ?? 'unknown'} has no valid issue date.`);
+}
+
+async function synchronizeCounters(billingPeriods, invoiceCounters) {
+  const existingNumbers = await billingPeriods.find(
+    { invoice_number: { $type: 'string' } },
+    { projection: { invoice_number: 1 } }
+  ).toArray();
+  const maximumSequenceByYear = new Map();
+
+  for (const period of existingNumbers) {
+    const match = INVOICE_NUMBER_PATTERN.exec(period.invoice_number);
+    if (!match) {
+      continue;
+    }
+
+    const [, year, sequenceValue] = match;
+    const sequence = Number(sequenceValue);
+    maximumSequenceByYear.set(
+      year,
+      Math.max(maximumSequenceByYear.get(year) ?? 0, sequence)
+    );
+  }
+
+  for (const [year, sequence] of maximumSequenceByYear) {
+    await invoiceCounters.updateOne(
+      { _id: `invoice:${year}` },
+      { $max: { sequence } },
+      { upsert: true }
+    );
+  }
+}
+
+async function allocateInvoiceNumber(invoiceCounters, issueDate) {
+  const year = getInvoiceYear(issueDate);
+  const counter = await invoiceCounters.findOneAndUpdate(
+    { _id: `invoice:${year}` },
+    { $inc: { sequence: 1 } },
+    {
+      upsert: true,
+      returnDocument: 'after',
+    }
+  );
+
+  if (!counter) {
+    throw new Error(`Could not allocate an invoice number for ${year}.`);
+  }
+
+  return `AZP${year}${counter.sequence.toString().padStart(4, '0')}`;
+}
+
+async function main() {
+  const uri = process.env.db_uri;
+  const dbName = process.env.db_name || DEFAULT_DATABASE_NAME;
+
+  if (!uri) {
+    throw new Error('Missing db_uri. Add it to .env or your environment.');
+  }
+
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    const database = client.db(dbName);
+    const billingPeriods = database.collection('billing_periods');
+    const invoiceCounters = database.collection('invoice_counters');
+    const periods = await billingPeriods.find(MISSING_INVOICE_NUMBER)
+      .sort({ created_at: 1, _id: 1 })
+      .toArray();
+
+    await synchronizeCounters(billingPeriods, invoiceCounters);
+
+    let updatedCount = 0;
+    let skippedCount = 0;
+
+    for (const period of periods) {
+      const invoiceNumber = await allocateInvoiceNumber(
+        invoiceCounters,
+        getBillingPeriodIssueDate(period)
+      );
+      const result = await billingPeriods.updateOne(
+        {
+          _id: period._id,
+          ...MISSING_INVOICE_NUMBER,
+        },
+        {
+          $set: {
+            invoice_number: invoiceNumber,
+          },
+        }
+      );
+
+      if (result.modifiedCount === 1) {
+        updatedCount += 1;
+        console.log(`Assigned ${invoiceNumber} to billing period ${period._id}.`);
+      } else {
+        skippedCount += 1;
+      }
+    }
+
+    console.log(`Done. Updated ${updatedCount} billing period(s); skipped ${skippedCount}.`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["api/**/*.ts"]
+}


### PR DESCRIPTION
## What changed

- centralizes billing-period creation and initial invoice delivery in one billing service
- sends invoice emails for registration, scheduled renewal, fallback renewal, manual creation, and repair-created periods
- introduces persisted yearly invoice numbers in the compact `AZPYYYYNNNN` format with an atomic MongoDB counter
- removes club IDs and legacy reference generation from new invoice numbers
- adds and runs a reusable invoice-number backfill migration
- localizes registration email role/status values and formats registration timestamps in German
- documents invoice triggers, recipients, delivery behavior, and numbering in `PLANS.md`
- bumps the application to `0.0.20`
- adds API TypeScript checking to the production build

## Why

Billing-period creation and invoice delivery had evolved as separate caller responsibilities. Fallback renewals could therefore create a period without sending its invoice. This refactor makes the invoice attempt part of the centralized billing workflow while preserving created periods when SMTP delivery fails.

## Impact

Every newly created billing period now receives a persisted invoice number and attempts invoice delivery exactly once through the centralized creation workflow. Resending an existing invoice remains a separate explicit action. Registration reports an invoice-delivery warning without rolling back successful club and billing-period creation.

## Validation

- `npm run build`
- `node --check scripts/backfill-billing-period-invoice-numbers.js`
- `git diff --check`
- production database backed up before migration
- invoice-number backfill run against production and verified idempotent

## Known repository issue

`npm run lint` cannot run because the repository does not yet contain an ESLint 9 flat configuration file.