### PR TITLE
Release 0.0.22 member and club updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project should be documented in this file.
 
+## 0.0.22
+
+### Changed
+
+- Changed member administration so admin users are explicitly shown as non-deactivatable and the API returns a specific error when admin deactivation is attempted.
+- Changed reservation listing to derive the club from the authenticated user instead of requiring a `club_id` query parameter.
+- Changed recurring reservation deletion to default to deleting the entire series when `delete_type` is omitted.
+- Changed the inactive-account warning so it is only shown after a user belongs to a club.
+- Changed the inactive-account warning to tell newly registered users to wait for club-admin activation before contacting the administrator if activation remains pending.
+- Changed the inactive-account warning to display the club administrator's email address alongside their name.
+- Changed the profile page to show the club-change action as an inline link after the club name.
+- Renamed the club-leave button from “Kein Verein” to the action-oriented “Verein verlassen.”
+- Moved the missing-club guidance into the club-selection form below the submit button.
+- Changed club selection to keep the user's current club in the dropdown so it remains available after leaving.
+- Changed the club-change warning to state that active reservations in the current club are deleted when switching or leaving.
+- Changed club selection to disable submission when the user's current club is selected.
+
 ## 0.0.21
 
 ### Added

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -301,3 +301,4 @@ Implementation details:
 - `delete=true`: marks the request as a delete operation
 - `date`: the selected occurrence date to delete
 - `delete_type`: `once`, `once_and_future`, or `all`
+- If `delete_type` is omitted, it defaults to `all`.

--- a/api/_utils/_deleteReservation.ts
+++ b/api/_utils/_deleteReservation.ts
@@ -29,6 +29,7 @@ const previousOccurrencesWereDeleted = (reservation: ReservationItem, selectedDa
 export const deleteReservation = async (req: VercelRequest, res: VercelResponse, reservations: Collection<ReservationItem>,
   users: Collection<DBUser>) => {
     const reservation_id = req.body?.reservation_id;
+    const deleteType = req.body?.delete_type ?? 'all';
     if (!reservation_id || typeof reservation_id !== 'string') {
       const { status, body } = getAppErrorResponse('RESERVATION_ID_REQUIRED');
       return res.status(status).json(body);
@@ -80,7 +81,7 @@ export const deleteReservation = async (req: VercelRequest, res: VercelResponse,
     }
 
     // delete reservation from db
-    if (!reservationIsRecurring || req.body.delete_type === 'all') {
+    if (!reservationIsRecurring || deleteType === 'all') {
       const result = await reservations.deleteOne(query);
       if (result.deletedCount > 0) {
         await returnResponse();
@@ -89,7 +90,7 @@ export const deleteReservation = async (req: VercelRequest, res: VercelResponse,
         return res.status(500).json(body);
       }
     // add req.body.date to deleted_dates array of reservation doc in db
-    } else if (req.body.delete_type === 'once') {
+    } else if (deleteType === 'once') {
       if (reservation.deleted_dates) {
         reservation.deleted_dates.push(req.body.date);
       } else {

--- a/api/reservations.ts
+++ b/api/reservations.ts
@@ -36,33 +36,23 @@ export default async (req: VercelRequest, res: VercelResponse) => {
     const users = database.collection<DBUser>('users');
 
     if (req.method === 'GET') {
-      const club_id = req.query?.club_id;
-      if (club_id) {
-        if (Array.isArray(club_id)) {
-          return res.status(400).json({error: 'Club id is invalid'});
-        }
-
-        const payload = await getJwtPayload(req);
-        if (!payload) {
-          return res.status(401).json({error: 'Authentication required'});
-        }
-
-        const user = await users.findOne({
-          _id: ObjectId.createFromHexString(payload._id)
-        });
-        if (!user) {
-          return res.status(401).json({error: 'Authentication required'});
-        }
-
-        if (user.club_id !== club_id) {
-          return res.status(403).json({error: 'Reading these reservations is not allowed'});
-        }
-
-        const docs = await getAllReservations(reservations, club_id);
-        res.json(docs);
-      } else {
-        res.status(500).end();
+      const payload = await getJwtPayload(req);
+      if (!payload) {
+        return res.status(401).json({error: 'Authentication required'});
       }
+
+      const user = await users.findOne({
+        _id: ObjectId.createFromHexString(payload._id)
+      });
+      if (!user) {
+        return res.status(401).json({error: 'Authentication required'});
+      }
+      if (!user.club_id) {
+        return res.status(403).json({error: 'User does not belong to a club'});
+      }
+
+      const docs = await getAllReservations(reservations, user.club_id);
+      return res.json(docs);
     }
 
     if (req.method === 'POST') {

--- a/api/users.ts
+++ b/api/users.ts
@@ -218,7 +218,11 @@ export default async (req: VercelRequest, res: VercelResponse) => {
           return res.status(403).json({error: 'Updating this member is not allowed'});
         }
         if (targetUser.role === 'admin') {
-          return res.status(403).json({error: 'Admin users cannot be changed here'});
+          return res.status(403).json({
+            error: action === 'deactivate'
+              ? 'Admin users cannot be deactivated'
+              : 'Admin users cannot be changed here'
+          });
         }
         if (action === 'remove' && targetUser.status === 'active') {
           return res.status(400).json({error: 'Only inactive members can be removed from club'});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abzumplatz",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abzumplatz",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
         "@reduxjs/toolkit": "^2.7.0",
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "abzumplatz",
   "private": true,
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/rest/billing.rest
+++ b/rest/billing.rest
@@ -17,8 +17,8 @@ Authorization: Bearer <token>
 
 {
     "club_id": "686f544e85081abe19f78156",
-    "period_start": "2026-06-17",
-    "period_end": "2026-07-17",
+    "period_start": "2026-08-17",
+    "period_end": "2026-09-17",
     "status": "active",
     "source": "manual-stage-insert"
 }
@@ -27,7 +27,7 @@ Authorization: Bearer <token>
 
 // note:
 // - period_end is the next renewal boundary
-// - the derived user-facing "bezahlt bis" date for this example would be 2026-07-16
+// - the derived user-facing "bezahlt bis" date for this example would be 2026-09-16
 // - make sure there is no other active billing period for the same club before inserting
 
 ###

--- a/rest/club.rest
+++ b/rest/club.rest
@@ -3,17 +3,24 @@ GET http://localhost:3000/api/clubs
 
 ###
 
-// registers a club, a date field in ISO format is added during insertion by api
-// only admins can register a club and new club's id is added to user in db after club is inserted and api returns id of the club
+// registers a club; timestamp is added during insertion
+// the authenticated admin must not already belong to a club
+// after insertion, the new club id is assigned to the admin and returned by the API
 POST http://localhost:3000/api/clubs
 Content-Type: application/json
 Authorization: Bearer <token>
 
 {
-    "name": "Bike Club",
+    "name": "Biking Club",
+    "address_line1": "Musterstraße 12",
+    "postal_code": "79183",
+    "city": "Waldkirch",
+    "country": "Deutschland",
+    "plan_type": "basic",
     "courts_count": 5,
     "start_hour": 9,
     "end_hour": 21,
+    "timezone": "Europe/Berlin",
     "reservations_limit": 3
 }
 

--- a/rest/login.rest
+++ b/rest/login.rest
@@ -2,6 +2,6 @@ POST http://localhost:3000/api/login
 Content-Type: application/json
 
 {
-    "email": "",
-    "password": ""
+    "email": "user@example.com",
+    "password": "Password?1"
 }

--- a/rest/reservation.rest
+++ b/rest/reservation.rest
@@ -1,37 +1,33 @@
-// get all reservations
-GET http://localhost:3000/api/reservations?club_id=67a501832225683fb61ca069
+// get all reservations for the authenticated user's club
+GET http://localhost:3000/api/reservations
+Authorization: Bearer <token>
 
 ###
 
-// make a reservation in tsv by user silvia@test.de
+// make a reservation as a player; admins may include multiple court numbers
 POST http://localhost:3000/api/reservations
 Content-Type: application/json
 Authorization: Bearer <token>
-{
-  "court_num": "1",
-  "date": "2025-06-12",
-  "start_time": "18",
-  "end_time": "19"
-}
-
-###
-
-// make a reservation in waldkirch
-POST http://localhost:3000/api/reservations
-Content-Type: application/json
-Authorization: Bearer [add token here...]
 
 {
-  "court_num": "3",
-  "date": "2025-03-17",
-  "start_time": "14",
-  "end_time": "15"
+  "court_nums": [1],
+  "date": "2026-08-12",
+  "start_time": 18,
+  "end_time": 19,
+  "label": "Testing by Saeid..."
 }
 
 ###
 
 // delete a reservation
-DELETE http://localhost:3000/api/reservations?reservation_id=67d852d2ad76ec6b8cb5fe01
+// delete_type can be "once", "once_and_future", or "all" and defaults to "all"
+// include the selected occurrence date when using "once" or "once_and_future"
+POST http://localhost:3000/api/reservations
 Content-Type: application/json
-Authorization: Bearer [add token here...]
+Authorization: Bearer <token>
 
+{
+  "delete": "true",
+  "reservation_id": "6a6d9bf03e52fbfec7f0e598",
+  "delete_type": "all"
+}

--- a/rest/signup.rest
+++ b/rest/signup.rest
@@ -1,11 +1,14 @@
+// registers a new user
+// optionally provide club_id to register the user for an existing club
+// if club_id is omitted, the user is registered without a club
 POST http://localhost:3000/api/signup
 Content-Type: application/json
 
 {
-    "first_name": "Jackie",
-    "last_name": "Jones",
-    "role": "player",
-    "email": "jackie@test.com",
-    "password": "blahbalh?T23",
+    "first_name": "Samuel",
+    "last_name": "Joker",
+    "club_id": "686f544e85081abe19f78156",
+    "email": "joker@test.com",
+    "password": "Opengl?1",
     "privacy": "agree"
 }

--- a/rest/user.rest
+++ b/rest/user.rest
@@ -1,19 +1,22 @@
 // get all users of a club
 GET http://localhost:3000/api/users?club_id=686f544e85081abe19f78156
+Authorization: Bearer <token>
 
 ###
 
-// get a specific user by his id
-GET http://localhost:3000/api/users?id=6901c515e273031e29ad9619
+// get a specific user by id
+GET http://localhost:3000/api/users?id=6a099dfd05698e9c2042e18f
+Authorization: Bearer <token>
 
 ###
 
-// update user
+// update members; supported actions are activate, deactivate, and remove
+// remove is only allowed for an inactive member
 POST http://localhost:3000/api/users
-Content-Type: application/json  
+Content-Type: application/json
 Authorization: Bearer <token>
 
 {
-    "user_id": "6901c515e273031e29ad9619",
-    "status": "active"
+    "user_id": "6874df30846ca9c06325815e",
+    "action": "remove"
 }

--- a/src/app.css
+++ b/src/app.css
@@ -184,6 +184,10 @@ ul {
         margin: 0;
     }
 
+    .members-admin-checkbox {
+        pointer-events: none;
+    }
+
     .members-list-name--admin {
         font-weight: 700;
     }
@@ -223,6 +227,11 @@ ul {
     border-radius: 0.25em;
 }
 
+.members-warning-box,
+.inactive-status-warning {
+    font-weight: 400;
+}
+
 .inactive-status-warning {
     background: #fff4d6;
     border: 1px solid #e0c36c;
@@ -230,7 +239,6 @@ ul {
     padding: 0.85em 1em;
     margin: 0 0 1rem;
     border-radius: 0.25em;
-    font-weight: 600;
 }
 
 .members-form {
@@ -342,17 +350,6 @@ ul {
     color: #4b5b78;
     font-weight: 600;
     padding-right: 1rem;
-}
-
-.profile-actions {
-    width: 100%;
-    max-width: 36rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    margin-top: 1rem;
-    flex-wrap: wrap;
 }
 
 .billings-table .billings-table__period {

--- a/src/components/InactiveStatusWarning.tsx
+++ b/src/components/InactiveStatusWarning.tsx
@@ -17,7 +17,7 @@ export default function InactiveStatusWarning() {
     }
   }, [auth.club_id, auth.status, auth.value, dispatch, hasUsersForCurrentClub]);
 
-  if (!auth.value || auth.status !== 'inactive') {
+  if (!auth.value || auth.status !== 'inactive' || !auth.club_id) {
     return null;
   }
 
@@ -45,8 +45,9 @@ export default function InactiveStatusWarning() {
     <div className="inactive-status-warning" role="alert">
       {adminName ? (
         <>
-          Ihr Konto ist derzeit inaktiv. Bitte kontaktieren Sie Ihren Vereinsadministrator{' '}
-          <a href={adminMailto}>{adminName}</a>.
+          Ihr Konto wurde noch nicht aktiviert. Wenn Sie sich gerade registriert haben, warten Sie bitte, bis Ihr
+          Vereinsadministrator Ihr Konto freischaltet. Sollte Ihr Konto nach einiger Zeit noch nicht aktiviert sein,
+          kontaktieren Sie bitte Ihren Vereinsadministrator {adminName} (<a href={adminMailto}>{adminEmail}</a>).
         </>
       ) : (
         getInactiveUserMessage()

--- a/src/components/form/Form.css
+++ b/src/components/form/Form.css
@@ -70,6 +70,12 @@
         margin-top: 0.5em;
     }
 
+    .select-club-guidance {
+        margin-bottom: 0;
+        font-size: 0.875em;
+        color: #555;
+    }
+
     .row-error {
         .error {
             display: block;

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { ChangeEvent, SyntheticEvent } from 'react'
+import type { ChangeEvent, ReactNode, SyntheticEvent } from 'react'
 import { fetchJson } from '../../utils/utils.js';
 import { validateData } from '../../utils/validate.js';
 import Hint from '../Hint.js';
@@ -21,6 +21,8 @@ type Props = {
     callback?: Function;
     formData?: Field[];
     onFormDataChange?: (fields: Field[]) => void;
+    children?: ReactNode;
+    isSubmitDisabled?: (fields: Field[]) => boolean;
 }
 
 type Option = {
@@ -131,6 +133,9 @@ export function Form(props: Props) {
 
     async function submitHandler(event: SyntheticEvent<HTMLFormElement>) {
         event.preventDefault();
+        if (props.isSubmitDisabled?.(formData)) {
+            return;
+        }
         setDisabled(true);
         removeErrors();
 
@@ -336,8 +341,9 @@ export function Form(props: Props) {
             noValidate={formAttributes.disableBrowserValidation}>
             {getFields()}
             <div className="row">
-                <button disabled={disabled} type="submit">{label}</button>
+                <button disabled={disabled || props.isSubmitDisabled?.(formData)} type="submit">{label}</button>
             </div>
+            {props.children}
         </form>
     ) : <p>Loading...</p>
 }

--- a/src/components/selectClub/SelectClub.tsx
+++ b/src/components/selectClub/SelectClub.tsx
@@ -25,9 +25,7 @@ export function SelectClub(props: Props) {
     const dispatch = useDispatch();
     const auth = useSelector((state: RootState) => state.auth);
     const [pending, setPending] = useState(false);
-    const clubs = props.clubs
-        .filter(club => club._id !== auth.club_id)
-        .map(club => {
+    const clubs = props.clubs.map(club => {
         return {
             label: club.name,
             value: club._id,
@@ -117,12 +115,19 @@ export function SelectClub(props: Props) {
                 formAttributes={formJson.form}
                 label={auth.club_id ? 'Verein wechseln' : 'Absenden'}
                 callback={callback}
-            />
+                isSubmitDisabled={fields => Boolean(auth.club_id)
+                    && fields.find(field => field.name === 'club_id')?.value === auth.club_id}
+            >
+                <p className="select-club-guidance">
+                    Solltest du deinen Vereinsnamen nicht finden, wende dich an den Vorstand deines Vereins und bitte
+                    ihn, den Verein auf abzumplatz.de anzumelden.
+                </p>
+            </Form>
             {auth.club_id ? (
                 <p>
                     <button type="button" disabled={pending} onClick={leaveClub}>
                         {pending ? <Loader size="small" /> : null}
-                        Kein Verein
+                        Verein verlassen
                     </button>
                 </p>
             ) : null}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,4 +1,4 @@
 export const getInactiveUserMessage = (adminName?: string) => {
   const adminLabel = adminName ? `Vereinsadministrator ${adminName}` : 'Vereinsadministrator';
-  return `Ihr Konto ist derzeit inaktiv. Bitte kontaktieren Sie Ihren ${adminLabel}.`;
+  return `Ihr Konto wurde noch nicht aktiviert. Wenn Sie sich gerade registriert haben, warten Sie bitte, bis Ihr ${adminLabel} Ihr Konto freischaltet. Sollte Ihr Konto nach einiger Zeit noch nicht aktiviert sein, kontaktieren Sie bitte Ihren ${adminLabel}.`;
 };

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -25,7 +25,12 @@ export default function Profile() {
                     </tr>
                     <tr>
                         <th>Verein</th>
-                        <td>{club?.name ?? '-'}</td>
+                        <td>
+                            {club?.name ?? '-'}
+                            {auth.role !== 'admin' ? (
+                                <> (<Link to="/select-club">Verein wechseln</Link>)</>
+                            ) : null}
+                        </td>
                     </tr>
                     <tr>
                         <th>Email</th>
@@ -33,9 +38,6 @@ export default function Profile() {
                     </tr>
                 </tbody>
             </table>
-            <div className="profile-actions">
-                {auth.role !== 'admin' ? <Link className="button-link" to="/select-club">Verein wechseln</Link> : <span />}
-            </div>
         </>
     )
 }

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -185,7 +185,7 @@ export default function Reservations() {
         } else if (!reservationsData.loaded) {
             (async () => {
                 setLoading(true);
-                await fetchReservations(user.club_id, dispatch);
+                await fetchReservations(dispatch);
                 setLoading(false);
             })();
         }

--- a/src/pages/SelectClubPage.tsx
+++ b/src/pages/SelectClubPage.tsx
@@ -20,11 +20,10 @@ export default function SelectClubPage(props: Props) {
             <h1>{isChangingClub ? 'Verein wechseln' : 'Verein auswählen'}</h1>
             {isChangingClub ? <p>Aktueller Verein: <strong>{club?.name ?? '-'}</strong></p> : null}
             <p>{isChangingClub
-                ? 'Sie können Ihren Verein wechseln, solange Sie in Ihrem aktuellen Verein keine aktiven Reservierungen mehr haben.'
+                ? 'Wenn Sie Ihren Verein wechseln oder verlassen, werden alle aktiven Reservierungen in Ihrem aktuellen Verein gelöscht.'
                 : 'Bevor Sie mit der App fortfahren können, müssen Sie Ihren Club auswählen:'}
             </p>
             <SelectClub clubs={props.clubs} />
-            <p>Solltest du deinen Vereinsnamen nicht finden, wende dich an den Vorstand deines Vereins und bitte ihn, den Verein auf abzumplatz.de anzumelden.</p>
         </>
     )
 }

--- a/src/pages/admin/Members.tsx
+++ b/src/pages/admin/Members.tsx
@@ -94,6 +94,10 @@ export default function AdminMembersPage() {
         );
     };
 
+    const showAdminDeactivationHint = () => {
+        alert('Administratoren können nicht deaktiviert werden.');
+    };
+
     const selectableUsers = visibleUsers.filter(member => member.role !== 'admin');
     const allVisibleSelected = selectableUsers.length > 0 && selectableUsers.every(member => selectedUserIds.includes(member._id));
     const submitAction = activeTab === 'active' ? 'deactivate' : inactiveAction;
@@ -267,13 +271,21 @@ export default function AdminMembersPage() {
                                         <span className="members-list-email"><a href={`mailto:${user.email}`}>{user.email}</a></span>
                                     </label>
                                 ) : (
-                                    <label className="members-list-item" htmlFor={user._id}>
+                                    <label
+                                        className="members-list-item"
+                                        htmlFor={user._id}
+                                        onClick={event => {
+                                            if (!(event.target as HTMLElement).closest('a')) {
+                                                showAdminDeactivationHint();
+                                            }
+                                        }}
+                                    >
                                         <input
                                             id={user._id}
+                                            className="members-admin-checkbox"
                                             type="checkbox"
                                             checked={false}
-                                            disabled={true}
-                                            onChange={() => undefined}
+                                            disabled
                                         />
                                         <span className="members-list-name members-list-name--admin">
                                             {user.first_name} {user.last_name} (Admin)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -277,7 +277,7 @@ export const getAllReservations = async (
 
 export const fetchAppData = async (clubId: string, dispatch: AppDispatch) => {
     const usersEndpoint = `/api/users?club_id=${clubId}`;
-    const reservationsEndpoint = `/api/reservations?club_id=${clubId}`;
+    const reservationsEndpoint = '/api/reservations';
     const usersRequest: Promise<StateUser[]> = fetch(usersEndpoint)
         .then(res => res.json());
     const reservationsRequest: Promise<ReservationItem[]> = fetch(reservationsEndpoint)
@@ -332,8 +332,8 @@ export const fetchUsers = async (clubId: string, dispatch: AppDispatch) => {
     });
 };
 
-export const fetchReservations = async (clubId: string, dispatch: AppDispatch) => {
-    const reservationsEndpoint = `/api/reservations?club_id=${clubId}`;
+export const fetchReservations = async (dispatch: AppDispatch) => {
+    const reservationsEndpoint = '/api/reservations';
     const reservationsData = await fetch(reservationsEndpoint);
     const reservations: ReservationItem[] = await reservationsData.json();
     dispatch({


### PR DESCRIPTION
## Summary

- prevent administrators from being selected for deactivation and clarify the blocked action
- derive reservation listings from the authenticated user's club and update reservation deletion defaults
- improve inactive-account messaging and club/profile selection UX
- refresh REST request examples against the current API contracts
- bump the application version to 0.0.22

## Why

This release aligns member administration, reservation access, and club membership flows with their current backend rules while making potentially destructive club changes clearer to users.

## User impact

Users receive clearer activation guidance, can access club switching from their profile, see explicit reservation-deletion warnings when changing clubs, and cannot submit their current club as a switch target. Administrators remain protected from deactivation in both the UI and API.

## Validation

- `npm run build`
- `git diff --check`

ESLint was not run because the repository uses ESLint 9 without an `eslint.config.*` flat configuration file.